### PR TITLE
Port disassembler from rs-nes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ travis-ci = { repository = "https://github.com/bgourlie/asm6502", branch = "mast
 
 [dependencies]
 nom = "^2.0"
+serde = {version = "^0.9.2"}
+serde_json = {version = "^0.9.1"}
+serde_derive = {version = "^0.9.2"}

--- a/examples/disassembler.rs
+++ b/examples/disassembler.rs
@@ -1,19 +1,24 @@
 extern crate asm6502;
 
-use asm6502::InstructionDecoder;
+use asm6502::{Instruction, InstructionDecoder};
 use std::fs::File;
 use std::io::Read;
 
-const PC_START: usize = 0x400;
+const PC_START: u16 = 0x400;
 
 fn main() {
-    let mut f = File::open("test_roms/6502_functional_test.bin").unwrap();
+    let mut f = File::open("../rs-nes/test_roms/6502_functional_test.bin").unwrap();
     let mut rom = Vec::<u8>::new();
     let bytes_read = f.read_to_end(&mut rom).unwrap();
     assert!(bytes_read == 65536);
     let decoder = InstructionDecoder::new(&rom, PC_START);
 
-    for instr in decoder.take(100) {
-        println!("{}", instr.mnemonic.to_string());
+    for instruction in decoder.take(100) {
+        match instruction {
+            Instruction::Known(offset, mnemonic, am) => {
+                println!("{:0>4X}: {} {:?}", offset, mnemonic.to_string(), am)
+            }
+            Instruction::Undefined(offset) => println!("{:0>4X}: Undefined", offset),
+        }
     }
 }

--- a/examples/disassembler.rs
+++ b/examples/disassembler.rs
@@ -1,0 +1,19 @@
+extern crate asm6502;
+
+use asm6502::InstructionDecoder;
+use std::fs::File;
+use std::io::Read;
+
+const PC_START: usize = 0x400;
+
+fn main() {
+    let mut f = File::open("test_roms/6502_functional_test.bin").unwrap();
+    let mut rom = Vec::<u8>::new();
+    let bytes_read = f.read_to_end(&mut rom).unwrap();
+    assert!(bytes_read == 65536);
+    let decoder = InstructionDecoder::new(&rom, PC_START);
+
+    for instr in decoder.take(100) {
+        println!("{}", instr.mnemonic.to_string());
+    }
+}

--- a/src/disassembler/mod.rs
+++ b/src/disassembler/mod.rs
@@ -1,0 +1,402 @@
+static INSTR_MASK: u8 = 0b111;
+static INSTR_FAMILY_MASK: u8 = 0b11;
+static ADDRESSING_MODE_MASK: u8 = 0b111;
+
+pub struct InstructionDecoder<'a> {
+    bytes: &'a [u8],
+    pc: usize,
+    start_offset: u16,
+}
+
+#[derive(Copy, Clone)]
+pub struct Instruction {
+    pub offset: u16,
+    pub mnemonic: Mnemonic,
+    pub addressing_mode: AddressingMode,
+}
+
+#[derive(Copy, Clone)]
+pub enum AddressingMode {
+    IndexedIndirect(u8),
+    IndirectIndexed(u8),
+    ZeroPage(u8),
+    Immediate(u8),
+    Absolute(u16),
+    AbsoluteX(u16),
+    AbsoluteY(u16),
+    ZeroPageX(u8),
+    Relative(i8),
+    Implied,
+    Accumulator,
+}
+
+#[derive(Copy, Clone)]
+pub enum Mnemonic {
+    ADC,
+    AND,
+    ASL,
+    BCC,
+    BCS,
+    BEQ,
+    BIT,
+    BMI,
+    BNE,
+    BPL,
+    BRK,
+    BVC,
+    BVS,
+    CLC,
+    CLD,
+    CLI,
+    CLV,
+    CMP,
+    CPX,
+    CPY,
+    DEC,
+    DEX,
+    DEY,
+    EOR,
+    INC,
+    INX,
+    INY,
+    JMP,
+    JSR,
+    LDA,
+    LDX,
+    LDY,
+    LSR,
+    NOP,
+    ORA,
+    PHA,
+    PHP,
+    PLA,
+    PLP,
+    ROL,
+    ROR,
+    RTI,
+    RTS,
+    SBC,
+    SEC,
+    SED,
+    SEI,
+    STA,
+    STX,
+    STY,
+    TAX,
+    TAY,
+    TSX,
+    TXA,
+    TXS,
+    TYA,
+}
+
+impl ToString for Mnemonic {
+    fn to_string(&self) -> String {
+        match *self {
+                Mnemonic::ADC => "ADC",
+                Mnemonic::AND => "AND",
+                Mnemonic::ASL => "ASL",
+                Mnemonic::BCC => "BCC",
+                Mnemonic::BCS => "BCS",
+                Mnemonic::BEQ => "BEQ",
+                Mnemonic::BIT => "BIT",
+                Mnemonic::BMI => "BMI",
+                Mnemonic::BNE => "BNE",
+                Mnemonic::BPL => "BPL",
+                Mnemonic::BRK => "BRK",
+                Mnemonic::BVC => "BVC",
+                Mnemonic::BVS => "BVS",
+                Mnemonic::CLC => "CLC",
+                Mnemonic::CLD => "CLD",
+                Mnemonic::CLI => "CLI",
+                Mnemonic::CLV => "CLV",
+                Mnemonic::CMP => "CMP",
+                Mnemonic::CPX => "CPX",
+                Mnemonic::CPY => "CPU",
+                Mnemonic::DEC => "DEC",
+                Mnemonic::DEX => "DEX",
+                Mnemonic::DEY => "DEY",
+                Mnemonic::EOR => "EOR",
+                Mnemonic::INC => "INC",
+                Mnemonic::INX => "INX",
+                Mnemonic::INY => "INY",
+                Mnemonic::JMP => "JMP",
+                Mnemonic::JSR => "JSR",
+                Mnemonic::LDA => "LDA",
+                Mnemonic::LDX => "LDX",
+                Mnemonic::LDY => "LDY",
+                Mnemonic::LSR => "LSR",
+                Mnemonic::NOP => "NOP",
+                Mnemonic::ORA => "ORA",
+                Mnemonic::PHA => "PHA",
+                Mnemonic::PHP => "PHP",
+                Mnemonic::PLA => "PLA",
+                Mnemonic::PLP => "PLP",
+                Mnemonic::ROL => "ROL",
+                Mnemonic::ROR => "ROR",
+                Mnemonic::RTI => "RTI",
+                Mnemonic::RTS => "RTS",
+                Mnemonic::SBC => "SBC",
+                Mnemonic::SEC => "SEC",
+                Mnemonic::SED => "SED",
+                Mnemonic::SEI => "SEI",
+                Mnemonic::STA => "STA",
+                Mnemonic::STX => "STX",
+                Mnemonic::STY => "STY",
+                Mnemonic::TAX => "TAX",
+                Mnemonic::TAY => "TAY",
+                Mnemonic::TSX => "TSX",
+                Mnemonic::TXA => "TXA",
+                Mnemonic::TXS => "TXS",
+                Mnemonic::TYA => "TYA",
+            }
+            .to_string()
+    }
+}
+
+impl<'a> InstructionDecoder<'a> {
+    pub fn new(bytes: &'a [u8], start_offset: usize) -> Self {
+        InstructionDecoder {
+            bytes: &bytes[start_offset..],
+            pc: 0,
+            start_offset: start_offset as u16,
+        }
+    }
+
+    pub fn read(&mut self) -> Option<Instruction> {
+        self.read_instruction().and_then(|(opcode, instr, offset)| {
+            self.read_addressing_mode(opcode).map(|am| {
+                Instruction {
+                    offset: self.start_offset + offset,
+                    mnemonic: instr,
+                    addressing_mode: am,
+                }
+            })
+        })
+    }
+
+    fn read8(&mut self) -> Option<u8> {
+        let pc = self.pc;
+        if pc < self.bytes.len() {
+            let val = self.bytes[pc];
+            self.pc += 1;
+            Some(val)
+        } else {
+            None
+        }
+    }
+
+    fn read16(&mut self) -> Option<u16> {
+        let pc = self.pc;
+        if pc + 1 < self.bytes.len() {
+            let byte1 = self.bytes[pc];
+            let byte2 = self.bytes[pc + 1];
+            let val = byte1 as u16 | (byte2 as u16) << 8;
+            self.pc += 2;
+            Some(val)
+        } else {
+            None
+        }
+    }
+
+    fn read_indexed_indirect(&mut self) -> Option<AddressingMode> {
+        self.read8().map(AddressingMode::IndexedIndirect)
+    }
+
+    fn read_indirect_indexed(&mut self) -> Option<AddressingMode> {
+        self.read8().map(AddressingMode::IndirectIndexed)
+    }
+
+    fn read_zp(&mut self) -> Option<AddressingMode> {
+        self.read8().map(AddressingMode::ZeroPage)
+    }
+
+    fn read_immediate(&mut self) -> Option<AddressingMode> {
+        self.read8().map(AddressingMode::Immediate)
+    }
+
+    fn read_abs(&mut self) -> Option<AddressingMode> {
+        self.read16().map(AddressingMode::Absolute)
+    }
+
+    fn read_zpx(&mut self) -> Option<AddressingMode> {
+        self.read8().map(AddressingMode::ZeroPageX)
+    }
+
+    fn read_absy(&mut self) -> Option<AddressingMode> {
+        self.read16().map(AddressingMode::AbsoluteY)
+    }
+
+    fn read_absx(&mut self) -> Option<AddressingMode> {
+        self.read16().map(AddressingMode::AbsoluteX)
+    }
+
+    fn read_relative(&mut self) -> Option<AddressingMode> {
+        self.read8().map(|i| i as i8).map(AddressingMode::Relative)
+    }
+
+    fn read_instruction(&mut self) -> Option<(u8, Mnemonic, u16)> {
+        self.read8().and_then(|opcode| {
+            let offset = (self.pc as u16) - 1;
+            match opcode {
+                    0x0 => {
+                        self.pc += 1; // Break has an additional padding byte
+                        Some(Mnemonic::BRK)
+                    }
+                    0x40 => Some(Mnemonic::RTI),
+                    0x60 => Some(Mnemonic::RTS),
+                    0x08 => Some(Mnemonic::PHP),
+                    0x28 => Some(Mnemonic::PLP),
+                    0x48 => Some(Mnemonic::PHA),
+                    0x68 => Some(Mnemonic::PLA),
+                    0x88 => Some(Mnemonic::DEY),
+                    0xa8 => Some(Mnemonic::TAY),
+                    0xc8 => Some(Mnemonic::INY),
+                    0xe8 => Some(Mnemonic::INX),
+                    0x18 => Some(Mnemonic::CLC),
+                    0x38 => Some(Mnemonic::SEC),
+                    0x58 => Some(Mnemonic::CLI),
+                    0x78 => Some(Mnemonic::SEI),
+                    0x98 => Some(Mnemonic::TYA),
+                    0xb8 => Some(Mnemonic::CLV),
+                    0xd8 => Some(Mnemonic::CLD),
+                    0xf8 => Some(Mnemonic::SED),
+                    0x8a => Some(Mnemonic::TXA),
+                    0x9a => Some(Mnemonic::TXS),
+                    0xaa => Some(Mnemonic::TAX),
+                    0xba => Some(Mnemonic::TSX),
+                    0xca => Some(Mnemonic::DEX),
+                    0xea => Some(Mnemonic::NOP),
+                    0x10 => Some(Mnemonic::BPL),
+                    0x30 => Some(Mnemonic::BMI),
+                    0x50 => Some(Mnemonic::BVC),
+                    0x70 => Some(Mnemonic::BVS),
+                    0x90 => Some(Mnemonic::BCC),
+                    0xb0 => Some(Mnemonic::BCS),
+                    0xd0 => Some(Mnemonic::BNE),
+                    0xf0 => Some(Mnemonic::BEQ),
+                    0x20 => Some(Mnemonic::JSR),
+                    _ => {
+                        let instr_fam = opcode & INSTR_FAMILY_MASK;
+                        match instr_fam {
+                            0b01 => Self::decode_family01_instruction(opcode),
+                            0b10 => Self::decode_family10_instruction(opcode),
+                            0b00 => Self::decode_family00_instruction(opcode),
+                            _ => None,
+                        }
+                    }
+                }
+                .map(|instr| (opcode, instr, offset))
+        })
+    }
+
+    fn read_addressing_mode(&mut self, opcode: u8) -> Option<AddressingMode> {
+        match opcode {
+            0x0 | 0x40 | 0x60 | 0x08 | 0x28 | 0x48 | 0x68 | 0x88 | 0xa8 | 0xc8 | 0xe8 | 0x18 |
+            0x38 | 0x58 | 0x78 | 0x98 | 0xb8 | 0xd8 | 0xf8 | 0x8a | 0x9a | 0xaa | 0xba | 0xca |
+            0xea => Some(AddressingMode::Implied),
+            0x10 | 0x30 | 0x50 | 0x70 | 0x90 | 0xb0 | 0xd0 | 0xf0 => self.read_relative(),
+            0x20 => self.read_abs(),
+            _ => {
+                let instr_fam = opcode & INSTR_FAMILY_MASK;
+                match instr_fam {
+                    0b01 => self.decode_family01_addressing_mode(opcode),
+                    0b10 => self.decode_family10_addressing_mode(opcode),
+                    0b00 => self.decode_family00_addressing_mode(opcode),
+                    _ => None,
+                }
+            }
+        }
+    }
+
+    fn decode_family01_addressing_mode(&mut self, opcode: u8) -> Option<AddressingMode> {
+        let am = (opcode >> 2) & ADDRESSING_MODE_MASK;
+        match am {
+            0b0 => self.read_indexed_indirect(),
+            0b1 => self.read_zp(),
+            0b10 => self.read_immediate(),
+            0b11 => self.read_abs(),
+            0b100 => self.read_indirect_indexed(),
+            0b101 => self.read_zpx(),
+            0b110 => self.read_absy(),
+            0b111 => self.read_absx(),
+            _ => None,
+        }
+    }
+
+    fn decode_family10_addressing_mode(&mut self, opcode: u8) -> Option<AddressingMode> {
+        let am = (opcode >> 2) & ADDRESSING_MODE_MASK;
+        match am {
+            0b0 => self.read_immediate(),
+            0b1 => self.read_zp(),
+            0b10 => Some(AddressingMode::Accumulator),
+            0b11 => self.read_abs(),
+            0b101 => self.read_zpx(),
+            0b111 => self.read_absx(),
+            _ => None,
+        }
+    }
+
+    fn decode_family00_addressing_mode(&mut self, opcode: u8) -> Option<AddressingMode> {
+        let am = (opcode >> 2) & ADDRESSING_MODE_MASK;
+        match am {
+            0b0 => self.read_immediate(),
+            0b1 => self.read_zp(),
+            0b11 => self.read_abs(),
+            0b101 => self.read_zpx(),
+            0b111 => self.read_absx(),
+            _ => None,
+        }
+    }
+
+    fn decode_family01_instruction(opcode: u8) -> Option<Mnemonic> {
+        let instr = (opcode >> 5) & INSTR_MASK;
+        match instr {
+            0b0 => Some(Mnemonic::ORA),
+            0b1 => Some(Mnemonic::AND),
+            0b10 => Some(Mnemonic::EOR),
+            0b11 => Some(Mnemonic::ADC),
+            0b100 => Some(Mnemonic::STA),
+            0b101 => Some(Mnemonic::LDA),
+            0b110 => Some(Mnemonic::CMP),
+            0b111 => Some(Mnemonic::SBC),
+            _ => None,
+        }
+    }
+
+    fn decode_family00_instruction(opcode: u8) -> Option<Mnemonic> {
+        let instr = (opcode >> 5) & INSTR_MASK;
+        match instr {
+            0b1 => Some(Mnemonic::BIT),
+            0b10 | 0b11 => Some(Mnemonic::JMP),
+            0b100 => Some(Mnemonic::STY),
+            0b101 => Some(Mnemonic::LDY),
+            0b110 => Some(Mnemonic::CPY),
+            0b111 => Some(Mnemonic::CPX),
+            _ => None,
+        }
+    }
+
+    fn decode_family10_instruction(opcode: u8) -> Option<Mnemonic> {
+        let instr = (opcode >> 5) & INSTR_MASK;
+        match instr {
+            0b0 => Some(Mnemonic::ASL),
+            0b1 => Some(Mnemonic::ROL),
+            0b10 => Some(Mnemonic::LSR),
+            0b11 => Some(Mnemonic::ROR),
+            0b100 => Some(Mnemonic::STX),
+            0b101 => Some(Mnemonic::LDX),
+            0b110 => Some(Mnemonic::DEC),
+            0b111 => Some(Mnemonic::INC),
+            _ => None,
+        }
+    }
+}
+
+impl<'a> Iterator for InstructionDecoder<'a> {
+    type Item = Instruction;
+
+    fn next(&mut self) -> Option<Instruction> {
+        self.read()
+    }
+}

--- a/src/disassembler/mod.rs
+++ b/src/disassembler/mod.rs
@@ -1,3 +1,6 @@
+use serde::{Serialize, Serializer};
+use serde::ser::SerializeStruct;
+
 static INSTR_MASK: u8 = 0b111;
 static INSTR_FAMILY_MASK: u8 = 0b11;
 static ADDRESSING_MODE_MASK: u8 = 0b111;
@@ -8,7 +11,7 @@ pub struct InstructionDecoder<'a> {
     start_offset: u16,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Serialize)]
 pub struct Instruction {
     pub offset: u16,
     pub mnemonic: Mnemonic,
@@ -30,7 +33,60 @@ pub enum AddressingMode {
     Accumulator,
 }
 
-#[derive(Copy, Clone)]
+impl Serialize for AddressingMode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: Serializer
+    {
+        let mut state = serializer.serialize_struct("AddressingMode", 2)?;
+        match *self {
+            AddressingMode::IndexedIndirect(addr) => {
+                state.serialize_field("mode", "IndexedIndirect")?;
+                state.serialize_field("operand", &addr)?;
+            }
+            AddressingMode::IndirectIndexed(addr) => {
+                state.serialize_field("mode", "IndirectIndexed")?;
+                state.serialize_field("operand", &addr)?;
+            }
+            AddressingMode::ZeroPage(addr) => {
+                state.serialize_field("mode", "ZeroPage")?;
+                state.serialize_field("operand", &addr)?;
+            }
+            AddressingMode::Immediate(val) => {
+                state.serialize_field("mode", "Immediate")?;
+                state.serialize_field("operand", &val)?;
+            }
+            AddressingMode::Absolute(addr) => {
+                state.serialize_field("mode", "Absolute")?;
+                state.serialize_field("operand", &addr)?;
+            }
+            AddressingMode::AbsoluteX(addr) => {
+                state.serialize_field("mode", "AbsoluteX")?;
+                state.serialize_field("operand", &addr)?;
+            }
+            AddressingMode::AbsoluteY(addr) => {
+                state.serialize_field("mode", "AbsoluteY")?;
+                state.serialize_field("operand", &addr)?;
+            }
+            AddressingMode::ZeroPageX(addr) => {
+                state.serialize_field("mode", "ZeroPageX")?;
+                state.serialize_field("operand", &addr)?;
+            }
+            AddressingMode::Relative(offset) => {
+                state.serialize_field("mode", "Relative")?;
+                state.serialize_field("operand", &offset)?;
+            }
+            AddressingMode::Implied => {
+                state.serialize_field("mode", "Implied")?;
+            }
+            AddressingMode::Accumulator => {
+                state.serialize_field("mode", "Accumulator")?;
+            }
+        }
+        state.end()
+    }
+}
+
+#[derive(Copy, Clone, Serialize)]
 pub enum Mnemonic {
     ADC,
     AND,

--- a/src/disassembler/tests.rs
+++ b/src/disassembler/tests.rs
@@ -1,0 +1,302 @@
+use super::{AddressingMode, InstructionDecoder, Mnemonic};
+
+macro_rules! assert_disasm {
+    ( $ buf : expr , $ expect_mnemonic : expr , $ expect_am : expr ) => {
+        let buf = $buf;
+        let mut decoder = InstructionDecoder::new(buf, 0);
+        let expect_mnemonic = $expect_mnemonic;
+        let expect_am = $expect_am;
+
+        if let Some(instr) = decoder.read() {
+            assert_eq!(expect_mnemonic, instr.mnemonic);
+            assert_eq!(expect_am, instr.addressing_mode);
+            assert_eq!(buf.len(), decoder.pc)
+        } else {
+            panic!("Failed to disassemble {:?} into {:?} {:?}", &buf, expect_mnemonic, expect_am)
+        }
+    };
+}
+
+#[test]
+fn adc() {
+    assert_disasm!(&[0x69, 0x44], Mnemonic::ADC, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0x65, 0x44], Mnemonic::ADC, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0x75, 0x44], Mnemonic::ADC, AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x6d, 0x00, 0x44], Mnemonic::ADC, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x7d, 0x00, 0x44], Mnemonic::ADC, AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0x79, 0x00, 0x44], Mnemonic::ADC, AddressingMode::AbsoluteY(0x4400));
+    assert_disasm!(&[0x61, 0x44], Mnemonic::ADC, AddressingMode::IndexedIndirect(0x44));
+    assert_disasm!(&[0x71, 0x44], Mnemonic::ADC, AddressingMode::IndirectIndexed(0x44));
+}
+
+#[test]
+fn and() {
+    assert_disasm!(&[0x25, 0x44], Mnemonic::AND, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0x35, 0x44], Mnemonic::AND, AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x2d, 0x00, 0x44], Mnemonic::AND, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x3d, 0x00, 0x44], Mnemonic::AND, AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0x39, 0x00, 0x44], Mnemonic::AND, AddressingMode::AbsoluteY(0x4400));
+    assert_disasm!(&[0x21, 0x44], Mnemonic::AND, AddressingMode::IndexedIndirect(0x44));
+    assert_disasm!(&[0x31, 0x44], Mnemonic::AND, AddressingMode::IndirectIndexed(0x44));
+}
+
+#[test]
+fn asl() {
+    assert_disasm!(&[0x0a], Mnemonic::ASL, AddressingMode::Accumulator);
+    assert_disasm!(&[0x06, 0x44], Mnemonic::ASL, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0x16, 0x44], Mnemonic::ASL, AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x0e, 0x00, 0x44], Mnemonic::ASL, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x1e, 0x00, 0x44], Mnemonic::ASL, AddressingMode::AbsoluteX(0x4400));
+}
+
+#[test]
+fn bit() {
+    assert_disasm!(&[0x24, 0x44], Mnemonic::BIT, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0x2c, 0x00, 0x44], Mnemonic::BIT, AddressingMode::Absolute(0x4400));
+}
+
+#[test]
+fn branches() {
+    assert_disasm!(&[0x10, 0x44], Mnemonic::BPL, AddressingMode::Relative(0x44));
+    assert_disasm!(&[0x30, 0x44], Mnemonic::BMI, AddressingMode::Relative(0x44));
+    assert_disasm!(&[0x50, 0x44], Mnemonic::BVC, AddressingMode::Relative(0x44));
+    assert_disasm!(&[0x70, 0x44], Mnemonic::BVS, AddressingMode::Relative(0x44));
+    assert_disasm!(&[0x90, 0x44], Mnemonic::BCC, AddressingMode::Relative(0x44));
+    assert_disasm!(&[0xb0, 0x44], Mnemonic::BCS, AddressingMode::Relative(0x44));
+    assert_disasm!(&[0xd0, 0x44], Mnemonic::BNE, AddressingMode::Relative(0x44));
+    assert_disasm!(&[0xf0, 0x44], Mnemonic::BEQ, AddressingMode::Relative(0x44));
+}
+
+#[test]
+fn brk() {
+    // BRK is special in that even though it is a one byte instruction, it increments the pc by 1
+    let buf = &[0x0];
+    let mut decoder = InstructionDecoder::new(buf, 0);
+
+    if let Some(instr) = decoder.read() {
+        assert_eq!(Mnemonic::BRK, instr.mnemonic);
+        assert_eq!(AddressingMode::Implied, instr.addressing_mode);
+        assert_eq!(2, decoder.pc)
+    } else {
+        panic!("Failed to disassemble BRK instruction")
+    }
+}
+
+#[test]
+fn cmp() {
+    assert_disasm!(&[0xc9, 0x44], Mnemonic::CMP, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0xc5, 0x44], Mnemonic::CMP, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0xd5, 0x44], Mnemonic::CMP, AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0xcd, 0x00, 0x44], Mnemonic::CMP, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0xdd, 0x00, 0x44], Mnemonic::CMP, AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0xd9, 0x00, 0x44], Mnemonic::CMP, AddressingMode::AbsoluteY(0x4400));
+    assert_disasm!(&[0xc1, 0x44], Mnemonic::CMP, AddressingMode::IndexedIndirect(0x44));
+    assert_disasm!(&[0xd1, 0x44], Mnemonic::CMP, AddressingMode::IndirectIndexed(0x44));
+}
+
+#[test]
+fn cpx() {
+    assert_disasm!(&[0xe0, 0x44], Mnemonic::CPX, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0xe4, 0x44], Mnemonic::CPX, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0xec, 0x00, 0x44], Mnemonic::CPX, AddressingMode::Absolute(0x4400));
+}
+
+#[test]
+fn cpy() {
+    assert_disasm!(&[0xc0, 0x44], Mnemonic::CPY, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0xc4, 0x44], Mnemonic::CPY, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0xcc, 0x00, 0x44], Mnemonic::CPY, AddressingMode::Absolute(0x4400));
+}
+
+#[test]
+fn dec() {
+    assert_disasm!(&[0xc6, 0x44], Mnemonic::DEC, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0xd6, 0x44], Mnemonic::DEC, AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0xce, 0x00, 0x44], Mnemonic::DEC, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0xde, 0x00, 0x44], Mnemonic::DEC, AddressingMode::AbsoluteX(0x4400));
+}
+
+#[test]
+fn eor() {
+    assert_disasm!(&[0x49, 0x44], Mnemonic::EOR, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0x45, 0x44], Mnemonic::EOR, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0x55, 0x44], Mnemonic::EOR, AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x4d, 0x00, 0x44], Mnemonic::EOR, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x5d, 0x00, 0x44], Mnemonic::EOR, AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0x59, 0x00, 0x44], Mnemonic::EOR, AddressingMode::AbsoluteY(0x4400));
+    assert_disasm!(&[0x41, 0x44], Mnemonic::EOR, AddressingMode::IndexedIndirect(0x44));
+    assert_disasm!(&[0x51, 0x44], Mnemonic::EOR, AddressingMode::IndirectIndexed(0x44));
+}
+
+#[test]
+fn flag_instructions() {
+    assert_disasm!(&[0x18], Mnemonic::CLC, AddressingMode::Implied);
+    assert_disasm!(&[0x38], Mnemonic::SEC, AddressingMode::Implied);
+    assert_disasm!(&[0x58], Mnemonic::CLI, AddressingMode::Implied);
+    assert_disasm!(&[0x78], Mnemonic::SEI, AddressingMode::Implied);
+    assert_disasm!(&[0xb8], Mnemonic::CLV, AddressingMode::Implied);
+    assert_disasm!(&[0xd8], Mnemonic::CLD, AddressingMode::Implied);
+    assert_disasm!(&[0xf8], Mnemonic::SED, AddressingMode::Implied);
+}
+
+#[test]
+fn inc() {
+    assert_disasm!(&[0xe6, 0x44], Mnemonic::INC, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0xf6, 0x44], Mnemonic::INC, AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0xee, 0x00, 0x44], Mnemonic::INC, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0xfe, 0x00, 0x44], Mnemonic::INC, AddressingMode::AbsoluteX(0x4400));
+}
+
+#[test]
+fn jmp() {
+    assert_disasm!(&[0x4c, 0x97, 0x55], Mnemonic::JMP, AddressingMode::Absolute(0x5597));
+    assert_disasm!(&[0x6c, 0x97, 0x55], Mnemonic::JMP, AddressingMode::Indirect(0x5597));
+}
+
+#[test]
+fn jsr() {
+    assert_disasm!(&[0x20, 0x97, 0x55], Mnemonic::JSR, AddressingMode::Absolute(0x5597));
+}
+
+#[test]
+fn lda() {
+    assert_disasm!(&[0xa9, 0x44], Mnemonic::LDA, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0xa5, 0x44], Mnemonic::LDA, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0xb5, 0x44], Mnemonic::LDA, AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0xad, 0x00, 0x44], Mnemonic::LDA, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0xbd, 0x00, 0x44], Mnemonic::LDA, AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0xb9, 0x00, 0x44], Mnemonic::LDA, AddressingMode::AbsoluteY(0x4400));
+    assert_disasm!(&[0xa1, 0x44], Mnemonic::LDA, AddressingMode::IndexedIndirect(0x44));
+    assert_disasm!(&[0xb1, 0x44], Mnemonic::LDA, AddressingMode::IndirectIndexed(0x44));
+}
+
+#[test]
+fn ldx() {
+    assert_disasm!(&[0xa2, 0x44], Mnemonic::LDX, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0xa6, 0x44], Mnemonic::LDX, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0xb6, 0x44], Mnemonic::LDX, AddressingMode::ZeroPageY(0x44));
+    assert_disasm!(&[0xae, 0x00, 0x44], Mnemonic::LDX, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0xbe, 0x00, 0x44], Mnemonic::LDX, AddressingMode::AbsoluteY(0x4400));
+}
+
+#[test]
+fn ldy() {
+    assert_disasm!(&[0xa0, 0x44], Mnemonic::LDY, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0xa4, 0x44], Mnemonic::LDY, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0xb4, 0x44], Mnemonic::LDY, AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0xac, 0x00, 0x44], Mnemonic::LDY, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0xbc, 0x00, 0x44], Mnemonic::LDY, AddressingMode::AbsoluteX(0x4400));
+}
+
+#[test]
+fn lsr() {
+    assert_disasm!(&[0x4a], Mnemonic::LSR, AddressingMode::Accumulator);
+    assert_disasm!(&[0x46, 0x44], Mnemonic::LSR, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0x56, 0x44], Mnemonic::LSR, AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x4e, 0x00, 0x44], Mnemonic::LSR, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x5e, 0x00, 0x44], Mnemonic::LSR, AddressingMode::AbsoluteX(0x4400));
+}
+
+#[test]
+fn nop() {
+    assert_disasm!(&[0xea], Mnemonic::NOP, AddressingMode::Implied);
+}
+
+#[test]
+fn ora() {
+    assert_disasm!(&[0x09, 0x44], Mnemonic::ORA, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0x05, 0x44], Mnemonic::ORA, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0x15, 0x44], Mnemonic::ORA, AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x0d, 0x00, 0x44], Mnemonic::ORA, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x1d, 0x00, 0x44], Mnemonic::ORA, AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0x19, 0x00, 0x44], Mnemonic::ORA, AddressingMode::AbsoluteY(0x4400));
+    assert_disasm!(&[0x01, 0x44], Mnemonic::ORA, AddressingMode::IndexedIndirect(0x44));
+    assert_disasm!(&[0x11, 0x44], Mnemonic::ORA, AddressingMode::IndirectIndexed(0x44));
+}
+
+#[test]
+fn register_instructions() {
+    assert_disasm!(&[0xaa], Mnemonic::TAX, AddressingMode::Implied);
+    assert_disasm!(&[0x8a], Mnemonic::TXA, AddressingMode::Implied);
+    assert_disasm!(&[0xca], Mnemonic::DEX, AddressingMode::Implied);
+    assert_disasm!(&[0xe8], Mnemonic::INX, AddressingMode::Implied);
+    assert_disasm!(&[0xa8], Mnemonic::TAY, AddressingMode::Implied);
+    assert_disasm!(&[0x98], Mnemonic::TYA, AddressingMode::Implied);
+    assert_disasm!(&[0x88], Mnemonic::DEY, AddressingMode::Implied);
+    assert_disasm!(&[0xc8], Mnemonic::INY, AddressingMode::Implied);
+}
+
+#[test]
+fn rol() {
+    assert_disasm!(&[0x2a], Mnemonic::ROL, AddressingMode::Accumulator);
+    assert_disasm!(&[0x26, 0x44], Mnemonic::ROL, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0x36, 0x44], Mnemonic::ROL, AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x2e, 0x00, 0x44], Mnemonic::ROL, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x3e, 0x00, 0x44], Mnemonic::ROL, AddressingMode::AbsoluteX(0x4400));
+}
+
+#[test]
+fn ror() {
+    assert_disasm!(&[0x6a], Mnemonic::ROR, AddressingMode::Accumulator);
+    assert_disasm!(&[0x66, 0x44], Mnemonic::ROR, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0x76, 0x44], Mnemonic::ROR, AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x6e, 0x00, 0x44], Mnemonic::ROR, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x7e, 0x00, 0x44], Mnemonic::ROR, AddressingMode::AbsoluteX(0x4400));
+}
+
+#[test]
+fn rti() {
+    assert_disasm!(&[0x40], Mnemonic::RTI, AddressingMode::Implied);
+}
+
+#[test]
+fn rts() {
+    assert_disasm!(&[0x60], Mnemonic::RTS, AddressingMode::Implied);
+}
+
+#[test]
+fn sbc() {
+    assert_disasm!(&[0xe9, 0x44], Mnemonic::SBC, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0xe5, 0x44], Mnemonic::SBC, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0xf5, 0x44], Mnemonic::SBC, AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0xed, 0x00, 0x44], Mnemonic::SBC, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0xfd, 0x00, 0x44], Mnemonic::SBC, AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0xf9, 0x00, 0x44], Mnemonic::SBC, AddressingMode::AbsoluteY(0x4400));
+    assert_disasm!(&[0xe1, 0x44], Mnemonic::SBC, AddressingMode::IndexedIndirect(0x44));
+    assert_disasm!(&[0xf1, 0x44], Mnemonic::SBC, AddressingMode::IndirectIndexed(0x44));
+}
+
+#[test]
+fn sta() {
+    assert_disasm!(&[0x85, 0x44], Mnemonic::STA, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0x95, 0x44], Mnemonic::STA, AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x8d, 0x00, 0x44], Mnemonic::STA, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x9d, 0x00, 0x44], Mnemonic::STA, AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0x99, 0x00, 0x44], Mnemonic::STA, AddressingMode::AbsoluteY(0x4400));
+    assert_disasm!(&[0x81, 0x44], Mnemonic::STA, AddressingMode::IndexedIndirect(0x44));
+    assert_disasm!(&[0x91, 0x44], Mnemonic::STA, AddressingMode::IndirectIndexed(0x44));
+}
+
+#[test]
+fn stack_instruction() {
+    assert_disasm!(&[0x9a], Mnemonic::TXS, AddressingMode::Implied);
+    assert_disasm!(&[0xba], Mnemonic::TSX, AddressingMode::Implied);
+    assert_disasm!(&[0x48], Mnemonic::PHA, AddressingMode::Implied);
+    assert_disasm!(&[0x68], Mnemonic::PLA, AddressingMode::Implied);
+    assert_disasm!(&[0x08], Mnemonic::PHP, AddressingMode::Implied);
+    assert_disasm!(&[0x28], Mnemonic::PLP, AddressingMode::Implied);
+}
+
+#[test]
+fn stx() {
+    assert_disasm!(&[0x86, 0x44], Mnemonic::STX, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0x96, 0x44], Mnemonic::STX, AddressingMode::ZeroPageY(0x44));
+    assert_disasm!(&[0x8e, 0x00, 0x44], Mnemonic::STX, AddressingMode::Absolute(0x4400));
+}
+
+#[test]
+fn sty() {
+    assert_disasm!(&[0x84, 0x44], Mnemonic::STY, AddressingMode::ZeroPage(0x44));
+    assert_disasm!(&[0x94, 0x44], Mnemonic::STY, AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x8c, 0x00, 0x44], Mnemonic::STY, AddressingMode::Absolute(0x4400));
+}

--- a/src/disassembler/tests.rs
+++ b/src/disassembler/tests.rs
@@ -1,4 +1,4 @@
-use super::{AddressingMode, InstructionDecoder, Mnemonic};
+use super::{AddressingMode, Instruction, InstructionDecoder, Mnemonic};
 
 macro_rules! assert_disasm {
     ( $ buf : expr , $ expect_mnemonic : expr , $ expect_am : expr ) => {
@@ -7,10 +7,10 @@ macro_rules! assert_disasm {
         let expect_mnemonic = $expect_mnemonic;
         let expect_am = $expect_am;
 
-        if let Some(instr) = decoder.read() {
-            assert_eq!(expect_mnemonic, instr.mnemonic);
-            assert_eq!(expect_am, instr.addressing_mode);
-            assert_eq!(buf.len(), decoder.pc)
+        if let Some(Instruction::Known(_, mnemonic, am)) = decoder.next() {
+            assert_eq!(expect_mnemonic, mnemonic);
+            assert_eq!(expect_am, am);
+            assert_eq!(buf.len(), decoder.pc as usize)
         } else {
             panic!("Failed to disassemble {:?} into {:?} {:?}", &buf, expect_mnemonic, expect_am)
         }
@@ -19,40 +19,74 @@ macro_rules! assert_disasm {
 
 #[test]
 fn adc() {
-    assert_disasm!(&[0x69, 0x44], Mnemonic::ADC, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0x69, 0x44],
+                   Mnemonic::ADC,
+                   AddressingMode::Immediate(0x44));
     assert_disasm!(&[0x65, 0x44], Mnemonic::ADC, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0x75, 0x44], Mnemonic::ADC, AddressingMode::ZeroPageX(0x44));
-    assert_disasm!(&[0x6d, 0x00, 0x44], Mnemonic::ADC, AddressingMode::Absolute(0x4400));
-    assert_disasm!(&[0x7d, 0x00, 0x44], Mnemonic::ADC, AddressingMode::AbsoluteX(0x4400));
-    assert_disasm!(&[0x79, 0x00, 0x44], Mnemonic::ADC, AddressingMode::AbsoluteY(0x4400));
-    assert_disasm!(&[0x61, 0x44], Mnemonic::ADC, AddressingMode::IndexedIndirect(0x44));
-    assert_disasm!(&[0x71, 0x44], Mnemonic::ADC, AddressingMode::IndirectIndexed(0x44));
+    assert_disasm!(&[0x75, 0x44],
+                   Mnemonic::ADC,
+                   AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x6d, 0x00, 0x44],
+                   Mnemonic::ADC,
+                   AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x7d, 0x00, 0x44],
+                   Mnemonic::ADC,
+                   AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0x79, 0x00, 0x44],
+                   Mnemonic::ADC,
+                   AddressingMode::AbsoluteY(0x4400));
+    assert_disasm!(&[0x61, 0x44],
+                   Mnemonic::ADC,
+                   AddressingMode::IndexedIndirect(0x44));
+    assert_disasm!(&[0x71, 0x44],
+                   Mnemonic::ADC,
+                   AddressingMode::IndirectIndexed(0x44));
 }
 
 #[test]
 fn and() {
     assert_disasm!(&[0x25, 0x44], Mnemonic::AND, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0x35, 0x44], Mnemonic::AND, AddressingMode::ZeroPageX(0x44));
-    assert_disasm!(&[0x2d, 0x00, 0x44], Mnemonic::AND, AddressingMode::Absolute(0x4400));
-    assert_disasm!(&[0x3d, 0x00, 0x44], Mnemonic::AND, AddressingMode::AbsoluteX(0x4400));
-    assert_disasm!(&[0x39, 0x00, 0x44], Mnemonic::AND, AddressingMode::AbsoluteY(0x4400));
-    assert_disasm!(&[0x21, 0x44], Mnemonic::AND, AddressingMode::IndexedIndirect(0x44));
-    assert_disasm!(&[0x31, 0x44], Mnemonic::AND, AddressingMode::IndirectIndexed(0x44));
+    assert_disasm!(&[0x35, 0x44],
+                   Mnemonic::AND,
+                   AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x2d, 0x00, 0x44],
+                   Mnemonic::AND,
+                   AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x3d, 0x00, 0x44],
+                   Mnemonic::AND,
+                   AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0x39, 0x00, 0x44],
+                   Mnemonic::AND,
+                   AddressingMode::AbsoluteY(0x4400));
+    assert_disasm!(&[0x21, 0x44],
+                   Mnemonic::AND,
+                   AddressingMode::IndexedIndirect(0x44));
+    assert_disasm!(&[0x31, 0x44],
+                   Mnemonic::AND,
+                   AddressingMode::IndirectIndexed(0x44));
 }
 
 #[test]
 fn asl() {
     assert_disasm!(&[0x0a], Mnemonic::ASL, AddressingMode::Accumulator);
     assert_disasm!(&[0x06, 0x44], Mnemonic::ASL, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0x16, 0x44], Mnemonic::ASL, AddressingMode::ZeroPageX(0x44));
-    assert_disasm!(&[0x0e, 0x00, 0x44], Mnemonic::ASL, AddressingMode::Absolute(0x4400));
-    assert_disasm!(&[0x1e, 0x00, 0x44], Mnemonic::ASL, AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0x16, 0x44],
+                   Mnemonic::ASL,
+                   AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x0e, 0x00, 0x44],
+                   Mnemonic::ASL,
+                   AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x1e, 0x00, 0x44],
+                   Mnemonic::ASL,
+                   AddressingMode::AbsoluteX(0x4400));
 }
 
 #[test]
 fn bit() {
     assert_disasm!(&[0x24, 0x44], Mnemonic::BIT, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0x2c, 0x00, 0x44], Mnemonic::BIT, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x2c, 0x00, 0x44],
+                   Mnemonic::BIT,
+                   AddressingMode::Absolute(0x4400));
 }
 
 #[test]
@@ -73,9 +107,9 @@ fn brk() {
     let buf = &[0x0];
     let mut decoder = InstructionDecoder::new(buf, 0);
 
-    if let Some(instr) = decoder.read() {
-        assert_eq!(Mnemonic::BRK, instr.mnemonic);
-        assert_eq!(AddressingMode::Implied, instr.addressing_mode);
+    if let Some(Instruction::Known(_, mnemonic, am)) = decoder.next() {
+        assert_eq!(Mnemonic::BRK, mnemonic);
+        assert_eq!(AddressingMode::Implied, am);
         assert_eq!(2, decoder.pc)
     } else {
         panic!("Failed to disassemble BRK instruction")
@@ -84,48 +118,90 @@ fn brk() {
 
 #[test]
 fn cmp() {
-    assert_disasm!(&[0xc9, 0x44], Mnemonic::CMP, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0xc9, 0x44],
+                   Mnemonic::CMP,
+                   AddressingMode::Immediate(0x44));
     assert_disasm!(&[0xc5, 0x44], Mnemonic::CMP, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0xd5, 0x44], Mnemonic::CMP, AddressingMode::ZeroPageX(0x44));
-    assert_disasm!(&[0xcd, 0x00, 0x44], Mnemonic::CMP, AddressingMode::Absolute(0x4400));
-    assert_disasm!(&[0xdd, 0x00, 0x44], Mnemonic::CMP, AddressingMode::AbsoluteX(0x4400));
-    assert_disasm!(&[0xd9, 0x00, 0x44], Mnemonic::CMP, AddressingMode::AbsoluteY(0x4400));
-    assert_disasm!(&[0xc1, 0x44], Mnemonic::CMP, AddressingMode::IndexedIndirect(0x44));
-    assert_disasm!(&[0xd1, 0x44], Mnemonic::CMP, AddressingMode::IndirectIndexed(0x44));
+    assert_disasm!(&[0xd5, 0x44],
+                   Mnemonic::CMP,
+                   AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0xcd, 0x00, 0x44],
+                   Mnemonic::CMP,
+                   AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0xdd, 0x00, 0x44],
+                   Mnemonic::CMP,
+                   AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0xd9, 0x00, 0x44],
+                   Mnemonic::CMP,
+                   AddressingMode::AbsoluteY(0x4400));
+    assert_disasm!(&[0xc1, 0x44],
+                   Mnemonic::CMP,
+                   AddressingMode::IndexedIndirect(0x44));
+    assert_disasm!(&[0xd1, 0x44],
+                   Mnemonic::CMP,
+                   AddressingMode::IndirectIndexed(0x44));
 }
 
 #[test]
 fn cpx() {
-    assert_disasm!(&[0xe0, 0x44], Mnemonic::CPX, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0xe0, 0x44],
+                   Mnemonic::CPX,
+                   AddressingMode::Immediate(0x44));
     assert_disasm!(&[0xe4, 0x44], Mnemonic::CPX, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0xec, 0x00, 0x44], Mnemonic::CPX, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0xec, 0x00, 0x44],
+                   Mnemonic::CPX,
+                   AddressingMode::Absolute(0x4400));
 }
 
 #[test]
 fn cpy() {
-    assert_disasm!(&[0xc0, 0x44], Mnemonic::CPY, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0xc0, 0x44],
+                   Mnemonic::CPY,
+                   AddressingMode::Immediate(0x44));
     assert_disasm!(&[0xc4, 0x44], Mnemonic::CPY, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0xcc, 0x00, 0x44], Mnemonic::CPY, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0xcc, 0x00, 0x44],
+                   Mnemonic::CPY,
+                   AddressingMode::Absolute(0x4400));
 }
 
 #[test]
 fn dec() {
     assert_disasm!(&[0xc6, 0x44], Mnemonic::DEC, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0xd6, 0x44], Mnemonic::DEC, AddressingMode::ZeroPageX(0x44));
-    assert_disasm!(&[0xce, 0x00, 0x44], Mnemonic::DEC, AddressingMode::Absolute(0x4400));
-    assert_disasm!(&[0xde, 0x00, 0x44], Mnemonic::DEC, AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0xd6, 0x44],
+                   Mnemonic::DEC,
+                   AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0xce, 0x00, 0x44],
+                   Mnemonic::DEC,
+                   AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0xde, 0x00, 0x44],
+                   Mnemonic::DEC,
+                   AddressingMode::AbsoluteX(0x4400));
 }
 
 #[test]
 fn eor() {
-    assert_disasm!(&[0x49, 0x44], Mnemonic::EOR, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0x49, 0x44],
+                   Mnemonic::EOR,
+                   AddressingMode::Immediate(0x44));
     assert_disasm!(&[0x45, 0x44], Mnemonic::EOR, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0x55, 0x44], Mnemonic::EOR, AddressingMode::ZeroPageX(0x44));
-    assert_disasm!(&[0x4d, 0x00, 0x44], Mnemonic::EOR, AddressingMode::Absolute(0x4400));
-    assert_disasm!(&[0x5d, 0x00, 0x44], Mnemonic::EOR, AddressingMode::AbsoluteX(0x4400));
-    assert_disasm!(&[0x59, 0x00, 0x44], Mnemonic::EOR, AddressingMode::AbsoluteY(0x4400));
-    assert_disasm!(&[0x41, 0x44], Mnemonic::EOR, AddressingMode::IndexedIndirect(0x44));
-    assert_disasm!(&[0x51, 0x44], Mnemonic::EOR, AddressingMode::IndirectIndexed(0x44));
+    assert_disasm!(&[0x55, 0x44],
+                   Mnemonic::EOR,
+                   AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x4d, 0x00, 0x44],
+                   Mnemonic::EOR,
+                   AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x5d, 0x00, 0x44],
+                   Mnemonic::EOR,
+                   AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0x59, 0x00, 0x44],
+                   Mnemonic::EOR,
+                   AddressingMode::AbsoluteY(0x4400));
+    assert_disasm!(&[0x41, 0x44],
+                   Mnemonic::EOR,
+                   AddressingMode::IndexedIndirect(0x44));
+    assert_disasm!(&[0x51, 0x44],
+                   Mnemonic::EOR,
+                   AddressingMode::IndirectIndexed(0x44));
 }
 
 #[test]
@@ -142,59 +218,107 @@ fn flag_instructions() {
 #[test]
 fn inc() {
     assert_disasm!(&[0xe6, 0x44], Mnemonic::INC, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0xf6, 0x44], Mnemonic::INC, AddressingMode::ZeroPageX(0x44));
-    assert_disasm!(&[0xee, 0x00, 0x44], Mnemonic::INC, AddressingMode::Absolute(0x4400));
-    assert_disasm!(&[0xfe, 0x00, 0x44], Mnemonic::INC, AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0xf6, 0x44],
+                   Mnemonic::INC,
+                   AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0xee, 0x00, 0x44],
+                   Mnemonic::INC,
+                   AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0xfe, 0x00, 0x44],
+                   Mnemonic::INC,
+                   AddressingMode::AbsoluteX(0x4400));
 }
 
 #[test]
 fn jmp() {
-    assert_disasm!(&[0x4c, 0x97, 0x55], Mnemonic::JMP, AddressingMode::Absolute(0x5597));
-    assert_disasm!(&[0x6c, 0x97, 0x55], Mnemonic::JMP, AddressingMode::Indirect(0x5597));
+    assert_disasm!(&[0x4c, 0x97, 0x55],
+                   Mnemonic::JMP,
+                   AddressingMode::Absolute(0x5597));
+    assert_disasm!(&[0x6c, 0x97, 0x55],
+                   Mnemonic::JMP,
+                   AddressingMode::Indirect(0x5597));
 }
 
 #[test]
 fn jsr() {
-    assert_disasm!(&[0x20, 0x97, 0x55], Mnemonic::JSR, AddressingMode::Absolute(0x5597));
+    assert_disasm!(&[0x20, 0x97, 0x55],
+                   Mnemonic::JSR,
+                   AddressingMode::Absolute(0x5597));
 }
 
 #[test]
 fn lda() {
-    assert_disasm!(&[0xa9, 0x44], Mnemonic::LDA, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0xa9, 0x44],
+                   Mnemonic::LDA,
+                   AddressingMode::Immediate(0x44));
     assert_disasm!(&[0xa5, 0x44], Mnemonic::LDA, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0xb5, 0x44], Mnemonic::LDA, AddressingMode::ZeroPageX(0x44));
-    assert_disasm!(&[0xad, 0x00, 0x44], Mnemonic::LDA, AddressingMode::Absolute(0x4400));
-    assert_disasm!(&[0xbd, 0x00, 0x44], Mnemonic::LDA, AddressingMode::AbsoluteX(0x4400));
-    assert_disasm!(&[0xb9, 0x00, 0x44], Mnemonic::LDA, AddressingMode::AbsoluteY(0x4400));
-    assert_disasm!(&[0xa1, 0x44], Mnemonic::LDA, AddressingMode::IndexedIndirect(0x44));
-    assert_disasm!(&[0xb1, 0x44], Mnemonic::LDA, AddressingMode::IndirectIndexed(0x44));
+    assert_disasm!(&[0xb5, 0x44],
+                   Mnemonic::LDA,
+                   AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0xad, 0x00, 0x44],
+                   Mnemonic::LDA,
+                   AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0xbd, 0x00, 0x44],
+                   Mnemonic::LDA,
+                   AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0xb9, 0x00, 0x44],
+                   Mnemonic::LDA,
+                   AddressingMode::AbsoluteY(0x4400));
+    assert_disasm!(&[0xa1, 0x44],
+                   Mnemonic::LDA,
+                   AddressingMode::IndexedIndirect(0x44));
+    assert_disasm!(&[0xb1, 0x44],
+                   Mnemonic::LDA,
+                   AddressingMode::IndirectIndexed(0x44));
 }
 
 #[test]
 fn ldx() {
-    assert_disasm!(&[0xa2, 0x44], Mnemonic::LDX, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0xa2, 0x44],
+                   Mnemonic::LDX,
+                   AddressingMode::Immediate(0x44));
     assert_disasm!(&[0xa6, 0x44], Mnemonic::LDX, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0xb6, 0x44], Mnemonic::LDX, AddressingMode::ZeroPageY(0x44));
-    assert_disasm!(&[0xae, 0x00, 0x44], Mnemonic::LDX, AddressingMode::Absolute(0x4400));
-    assert_disasm!(&[0xbe, 0x00, 0x44], Mnemonic::LDX, AddressingMode::AbsoluteY(0x4400));
+    assert_disasm!(&[0xb6, 0x44],
+                   Mnemonic::LDX,
+                   AddressingMode::ZeroPageY(0x44));
+    assert_disasm!(&[0xae, 0x00, 0x44],
+                   Mnemonic::LDX,
+                   AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0xbe, 0x00, 0x44],
+                   Mnemonic::LDX,
+                   AddressingMode::AbsoluteY(0x4400));
 }
 
 #[test]
 fn ldy() {
-    assert_disasm!(&[0xa0, 0x44], Mnemonic::LDY, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0xa0, 0x44],
+                   Mnemonic::LDY,
+                   AddressingMode::Immediate(0x44));
     assert_disasm!(&[0xa4, 0x44], Mnemonic::LDY, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0xb4, 0x44], Mnemonic::LDY, AddressingMode::ZeroPageX(0x44));
-    assert_disasm!(&[0xac, 0x00, 0x44], Mnemonic::LDY, AddressingMode::Absolute(0x4400));
-    assert_disasm!(&[0xbc, 0x00, 0x44], Mnemonic::LDY, AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0xb4, 0x44],
+                   Mnemonic::LDY,
+                   AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0xac, 0x00, 0x44],
+                   Mnemonic::LDY,
+                   AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0xbc, 0x00, 0x44],
+                   Mnemonic::LDY,
+                   AddressingMode::AbsoluteX(0x4400));
 }
 
 #[test]
 fn lsr() {
     assert_disasm!(&[0x4a], Mnemonic::LSR, AddressingMode::Accumulator);
     assert_disasm!(&[0x46, 0x44], Mnemonic::LSR, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0x56, 0x44], Mnemonic::LSR, AddressingMode::ZeroPageX(0x44));
-    assert_disasm!(&[0x4e, 0x00, 0x44], Mnemonic::LSR, AddressingMode::Absolute(0x4400));
-    assert_disasm!(&[0x5e, 0x00, 0x44], Mnemonic::LSR, AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0x56, 0x44],
+                   Mnemonic::LSR,
+                   AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x4e, 0x00, 0x44],
+                   Mnemonic::LSR,
+                   AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x5e, 0x00, 0x44],
+                   Mnemonic::LSR,
+                   AddressingMode::AbsoluteX(0x4400));
 }
 
 #[test]
@@ -204,14 +328,28 @@ fn nop() {
 
 #[test]
 fn ora() {
-    assert_disasm!(&[0x09, 0x44], Mnemonic::ORA, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0x09, 0x44],
+                   Mnemonic::ORA,
+                   AddressingMode::Immediate(0x44));
     assert_disasm!(&[0x05, 0x44], Mnemonic::ORA, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0x15, 0x44], Mnemonic::ORA, AddressingMode::ZeroPageX(0x44));
-    assert_disasm!(&[0x0d, 0x00, 0x44], Mnemonic::ORA, AddressingMode::Absolute(0x4400));
-    assert_disasm!(&[0x1d, 0x00, 0x44], Mnemonic::ORA, AddressingMode::AbsoluteX(0x4400));
-    assert_disasm!(&[0x19, 0x00, 0x44], Mnemonic::ORA, AddressingMode::AbsoluteY(0x4400));
-    assert_disasm!(&[0x01, 0x44], Mnemonic::ORA, AddressingMode::IndexedIndirect(0x44));
-    assert_disasm!(&[0x11, 0x44], Mnemonic::ORA, AddressingMode::IndirectIndexed(0x44));
+    assert_disasm!(&[0x15, 0x44],
+                   Mnemonic::ORA,
+                   AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x0d, 0x00, 0x44],
+                   Mnemonic::ORA,
+                   AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x1d, 0x00, 0x44],
+                   Mnemonic::ORA,
+                   AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0x19, 0x00, 0x44],
+                   Mnemonic::ORA,
+                   AddressingMode::AbsoluteY(0x4400));
+    assert_disasm!(&[0x01, 0x44],
+                   Mnemonic::ORA,
+                   AddressingMode::IndexedIndirect(0x44));
+    assert_disasm!(&[0x11, 0x44],
+                   Mnemonic::ORA,
+                   AddressingMode::IndirectIndexed(0x44));
 }
 
 #[test]
@@ -230,18 +368,30 @@ fn register_instructions() {
 fn rol() {
     assert_disasm!(&[0x2a], Mnemonic::ROL, AddressingMode::Accumulator);
     assert_disasm!(&[0x26, 0x44], Mnemonic::ROL, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0x36, 0x44], Mnemonic::ROL, AddressingMode::ZeroPageX(0x44));
-    assert_disasm!(&[0x2e, 0x00, 0x44], Mnemonic::ROL, AddressingMode::Absolute(0x4400));
-    assert_disasm!(&[0x3e, 0x00, 0x44], Mnemonic::ROL, AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0x36, 0x44],
+                   Mnemonic::ROL,
+                   AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x2e, 0x00, 0x44],
+                   Mnemonic::ROL,
+                   AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x3e, 0x00, 0x44],
+                   Mnemonic::ROL,
+                   AddressingMode::AbsoluteX(0x4400));
 }
 
 #[test]
 fn ror() {
     assert_disasm!(&[0x6a], Mnemonic::ROR, AddressingMode::Accumulator);
     assert_disasm!(&[0x66, 0x44], Mnemonic::ROR, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0x76, 0x44], Mnemonic::ROR, AddressingMode::ZeroPageX(0x44));
-    assert_disasm!(&[0x6e, 0x00, 0x44], Mnemonic::ROR, AddressingMode::Absolute(0x4400));
-    assert_disasm!(&[0x7e, 0x00, 0x44], Mnemonic::ROR, AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0x76, 0x44],
+                   Mnemonic::ROR,
+                   AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x6e, 0x00, 0x44],
+                   Mnemonic::ROR,
+                   AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x7e, 0x00, 0x44],
+                   Mnemonic::ROR,
+                   AddressingMode::AbsoluteX(0x4400));
 }
 
 #[test]
@@ -256,25 +406,51 @@ fn rts() {
 
 #[test]
 fn sbc() {
-    assert_disasm!(&[0xe9, 0x44], Mnemonic::SBC, AddressingMode::Immediate(0x44));
+    assert_disasm!(&[0xe9, 0x44],
+                   Mnemonic::SBC,
+                   AddressingMode::Immediate(0x44));
     assert_disasm!(&[0xe5, 0x44], Mnemonic::SBC, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0xf5, 0x44], Mnemonic::SBC, AddressingMode::ZeroPageX(0x44));
-    assert_disasm!(&[0xed, 0x00, 0x44], Mnemonic::SBC, AddressingMode::Absolute(0x4400));
-    assert_disasm!(&[0xfd, 0x00, 0x44], Mnemonic::SBC, AddressingMode::AbsoluteX(0x4400));
-    assert_disasm!(&[0xf9, 0x00, 0x44], Mnemonic::SBC, AddressingMode::AbsoluteY(0x4400));
-    assert_disasm!(&[0xe1, 0x44], Mnemonic::SBC, AddressingMode::IndexedIndirect(0x44));
-    assert_disasm!(&[0xf1, 0x44], Mnemonic::SBC, AddressingMode::IndirectIndexed(0x44));
+    assert_disasm!(&[0xf5, 0x44],
+                   Mnemonic::SBC,
+                   AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0xed, 0x00, 0x44],
+                   Mnemonic::SBC,
+                   AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0xfd, 0x00, 0x44],
+                   Mnemonic::SBC,
+                   AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0xf9, 0x00, 0x44],
+                   Mnemonic::SBC,
+                   AddressingMode::AbsoluteY(0x4400));
+    assert_disasm!(&[0xe1, 0x44],
+                   Mnemonic::SBC,
+                   AddressingMode::IndexedIndirect(0x44));
+    assert_disasm!(&[0xf1, 0x44],
+                   Mnemonic::SBC,
+                   AddressingMode::IndirectIndexed(0x44));
 }
 
 #[test]
 fn sta() {
     assert_disasm!(&[0x85, 0x44], Mnemonic::STA, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0x95, 0x44], Mnemonic::STA, AddressingMode::ZeroPageX(0x44));
-    assert_disasm!(&[0x8d, 0x00, 0x44], Mnemonic::STA, AddressingMode::Absolute(0x4400));
-    assert_disasm!(&[0x9d, 0x00, 0x44], Mnemonic::STA, AddressingMode::AbsoluteX(0x4400));
-    assert_disasm!(&[0x99, 0x00, 0x44], Mnemonic::STA, AddressingMode::AbsoluteY(0x4400));
-    assert_disasm!(&[0x81, 0x44], Mnemonic::STA, AddressingMode::IndexedIndirect(0x44));
-    assert_disasm!(&[0x91, 0x44], Mnemonic::STA, AddressingMode::IndirectIndexed(0x44));
+    assert_disasm!(&[0x95, 0x44],
+                   Mnemonic::STA,
+                   AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x8d, 0x00, 0x44],
+                   Mnemonic::STA,
+                   AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x9d, 0x00, 0x44],
+                   Mnemonic::STA,
+                   AddressingMode::AbsoluteX(0x4400));
+    assert_disasm!(&[0x99, 0x00, 0x44],
+                   Mnemonic::STA,
+                   AddressingMode::AbsoluteY(0x4400));
+    assert_disasm!(&[0x81, 0x44],
+                   Mnemonic::STA,
+                   AddressingMode::IndexedIndirect(0x44));
+    assert_disasm!(&[0x91, 0x44],
+                   Mnemonic::STA,
+                   AddressingMode::IndirectIndexed(0x44));
 }
 
 #[test]
@@ -290,13 +466,21 @@ fn stack_instruction() {
 #[test]
 fn stx() {
     assert_disasm!(&[0x86, 0x44], Mnemonic::STX, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0x96, 0x44], Mnemonic::STX, AddressingMode::ZeroPageY(0x44));
-    assert_disasm!(&[0x8e, 0x00, 0x44], Mnemonic::STX, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x96, 0x44],
+                   Mnemonic::STX,
+                   AddressingMode::ZeroPageY(0x44));
+    assert_disasm!(&[0x8e, 0x00, 0x44],
+                   Mnemonic::STX,
+                   AddressingMode::Absolute(0x4400));
 }
 
 #[test]
 fn sty() {
     assert_disasm!(&[0x84, 0x44], Mnemonic::STY, AddressingMode::ZeroPage(0x44));
-    assert_disasm!(&[0x94, 0x44], Mnemonic::STY, AddressingMode::ZeroPageX(0x44));
-    assert_disasm!(&[0x8c, 0x00, 0x44], Mnemonic::STY, AddressingMode::Absolute(0x4400));
+    assert_disasm!(&[0x94, 0x44],
+                   Mnemonic::STY,
+                   AddressingMode::ZeroPageX(0x44));
+    assert_disasm!(&[0x8c, 0x00, 0x44],
+                   Mnemonic::STY,
+                   AddressingMode::Absolute(0x4400));
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,12 @@
 #[macro_use]
 extern crate nom;
 
+extern crate serde;
+extern crate serde_json;
+
+#[macro_use]
+extern crate serde_derive;
+
 mod assembler;
 mod disassembler;
 mod parser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,9 @@
 extern crate nom;
 
 mod assembler;
+mod disassembler;
 mod parser;
 mod tokens;
 
 pub use assembler::assemble;
+pub use disassembler::{AddressingMode, Instruction, InstructionDecoder, Mnemonic};


### PR DESCRIPTION
Currently, this pull request is a verbatim port from rs-nes. The current interface didn't have much thought put into it, so I'd like to reconsider how it's done. In particular, should `InstructionDecoder` return a struct that implements iterator instead of implementing itself? I need to figure out what would be considered the idiomatic approach.