### PR TITLE
Rewrite parser for nom v7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 repository = "https://github.com/bgourlie/asm6502"
 readme = "README.md"
 keywords = ["6502", "assembler"]
+edition = "2021"
 
 [badges]
 travis-ci = { repository = "bgourlie/asm6502", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ edition = "2021"
 travis-ci = { repository = "bgourlie/asm6502", branch = "master" }
 
 [dependencies]
-nom = "^2.0"
+nom = "7.0"

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -30,11 +30,8 @@ pub fn assemble<R: Read, W: Write>(mut input: R, output: &mut W) -> AssembleResu
     let mut buf = Vec::<u8>::new();
     input.read_to_end(&mut buf).map_err(|_| "Error reading input".to_owned())?;
     match parse_lines(&buf) {
-        IResult::Error(_) => Err("An error occurred while parsing".to_owned()),
-        IResult::Incomplete(_) => {
-            Err("An error occurred while parsing. Need more input.".to_owned())
-        }
-        IResult::Done(_, opcodes) => {
+        IResult::Err(_) => Err("An error occurred while parsing".to_owned()),
+        IResult::Ok((_, opcodes)) => {
             let mut res: AssembleResult = Ok(());
             for opcode in opcodes {
                 let OpCode(mnemonic, am) = opcode;

--- a/src/assembler/mod.rs
+++ b/src/assembler/mod.rs
@@ -2,9 +2,9 @@
 mod tests;
 
 use nom::IResult;
-use parser::parse_lines;
+use crate::parser::parse_lines;
 use std::io::{Read, Write};
-use tokens::*;
+use crate::tokens::*;
 
 type AssembleResult = Result<(), String>;
 

--- a/src/assembler/tests.rs
+++ b/src/assembler/tests.rs
@@ -16,18 +16,18 @@ macro_rules! assert_assemble {
         let asm = $asm;
         let mut buf = Vec::<u8>::new();
         match assemble(asm.as_bytes(), &mut buf) {
-            Err(msg) => panic!(format!("Failed to assemble '{}': {}", asm, msg)),
+            Err(msg) => panic!("Failed to assemble '{}': {}", asm, msg),
             _ => {
                 let expected = $expected;
                 let buf = &buf[..];
                 if expected.len() != buf.len() {
-                    panic!(format!("Expected number of bytes written for '{}' to be {} but was {}",
-                            asm, expected.len(), buf.len()))
+                    panic!("Expected number of bytes written for '{}' to be {} but was {}",
+                            asm, expected.len(), buf.len())
                 }
 
                 if expected != &buf[..] {
-                    panic!(format!("Expected '{}' to compile to {:?} but was {:?}",
-                            asm, expected, buf))
+                    panic!("Expected '{}' to compile to {:?} but was {:?}",
+                            asm, expected, buf)
                 }
             }
         }

--- a/src/assembler/tests.rs
+++ b/src/assembler/tests.rs
@@ -6,7 +6,7 @@ macro_rules! assert_assemble_err {
         let asm = $asm;
         match assemble(asm.as_bytes(), &mut buf) {
             Ok(_) => panic!("Expected error"),
-            _ => ()
+            _ => (),
         }
     };
 }
@@ -31,7 +31,7 @@ macro_rules! assert_assemble {
                 }
             }
         }
-    }}
+    }};
 }
 
 #[test]
@@ -61,7 +61,7 @@ fn adc() {
     assert_assemble!("ADC #$44", &[0x69, 0x44]);
 
     // Implied
-    assert_assemble_err!("ADC\n");
+    assert_assemble_err!("ADC");
 
     // Relative
     assert_assemble_err!("ADC -44");
@@ -103,7 +103,7 @@ fn and() {
     assert_assemble!("AND #$44", &[0x29, 0x44]);
 
     // Implied
-    assert_assemble_err!("AND\n");
+    assert_assemble_err!("AND");
 
     // Relative
     assert_assemble_err!("ADC -44");
@@ -145,7 +145,7 @@ fn asl() {
     assert_assemble_err!("ASL #$44");
 
     // Implied
-    assert_assemble_err!("ASL\n");
+    assert_assemble_err!("ASL");
 
     // Relative
     assert_assemble_err!("ASL -44");
@@ -187,7 +187,7 @@ fn bit() {
     assert_assemble_err!("BIT #$44");
 
     // Implied
-    assert_assemble_err!("BIT\n");
+    assert_assemble_err!("BIT");
 
     // Relative
     assert_assemble_err!("BIT -44");
@@ -229,7 +229,7 @@ fn bcc() {
     assert_assemble_err!("BCC #$44");
 
     // Implied
-    assert_assemble_err!("BCC\n");
+    assert_assemble_err!("BCC");
 
     // Relative
     assert_assemble!("BCC -44", &[0x90, 0xd4]);
@@ -268,7 +268,7 @@ fn bcs() {
     assert_assemble_err!("BCS #$44");
 
     // Implied
-    assert_assemble_err!("BCS\n");
+    assert_assemble_err!("BCS");
 
     // Relative
     assert_assemble!("BCS -44", &[0xb0, 0xd4]);
@@ -307,7 +307,7 @@ fn beq() {
     assert_assemble_err!("BEQ #$44");
 
     // Implied
-    assert_assemble_err!("BEQ\n");
+    assert_assemble_err!("BEQ");
 
     // Relative
     assert_assemble!("BEQ -44", &[0xf0, 0xd4]);
@@ -346,7 +346,7 @@ fn bmi() {
     assert_assemble_err!("BMI #$44");
 
     // Implied
-    assert_assemble_err!("BMI\n");
+    assert_assemble_err!("BMI");
 
     // Relative
     assert_assemble!("BMI -44", &[0x30, 0xd4]);
@@ -385,7 +385,7 @@ fn bne() {
     assert_assemble_err!("BNE #$44");
 
     // Implied
-    assert_assemble_err!("BNE\n");
+    assert_assemble_err!("BNE");
 
     // Relative
     assert_assemble!("BNE -44", &[0xd0, 0xd4]);
@@ -424,7 +424,7 @@ fn bpl() {
     assert_assemble_err!("BPL #$44");
 
     // Implied
-    assert_assemble_err!("BPL\n");
+    assert_assemble_err!("BPL");
 
     // Relative
     assert_assemble!("BPL -44", &[0x10, 0xd4]);
@@ -463,7 +463,7 @@ fn bvc() {
     assert_assemble_err!("BVC #$44");
 
     // Implied
-    assert_assemble_err!("BVC\n");
+    assert_assemble_err!("BVC");
 
     // Relative
     assert_assemble!("BVC -44", &[0x50, 0xd4]);
@@ -502,7 +502,7 @@ fn bvs() {
     assert_assemble_err!("BVS #$44");
 
     // Implied
-    assert_assemble_err!("BVS\n");
+    assert_assemble_err!("BVS");
 
     // Relative
     assert_assemble!("BVS -44", &[0x70, 0xd4]);
@@ -541,7 +541,7 @@ fn brk() {
     assert_assemble_err!("BRK #$44");
 
     // Implied
-    assert_assemble!("BRK\n", &[0x0, 0x0]);
+    assert_assemble!("BRK", &[0x0, 0x0]);
 
     // Relative
     assert_assemble_err!("BRK -44");
@@ -583,7 +583,7 @@ fn cmp() {
     assert_assemble!("CMP #$44", &[0xc9, 0x44]);
 
     // Implied
-    assert_assemble_err!("CMP\n");
+    assert_assemble_err!("CMP");
 
     // ZeroPage
     assert_assemble!("CMP $44", &[0xc5, 0x44]);
@@ -625,7 +625,7 @@ fn cpx() {
     assert_assemble!("CPX #$44", &[0xe0, 0x44]);
 
     // Implied
-    assert_assemble_err!("CPX\n");
+    assert_assemble_err!("CPX");
 
     // Relative
     assert_assemble_err!("CPX -44");
@@ -667,7 +667,7 @@ fn cpy() {
     assert_assemble!("CPY #$44", &[0xc0, 0x44]);
 
     // Implied
-    assert_assemble_err!("CPY\n");
+    assert_assemble_err!("CPY");
 
     // Relative
     assert_assemble_err!("CPY -44");
@@ -709,7 +709,7 @@ fn dec() {
     assert_assemble_err!("DEC #$44");
 
     // Implied
-    assert_assemble_err!("DEC\n");
+    assert_assemble_err!("DEC");
 
     // Relative
     assert_assemble_err!("DEC -44");
@@ -751,7 +751,7 @@ fn eor() {
     assert_assemble!("EOR #$44", &[0x49, 0x44]);
 
     // Implied
-    assert_assemble_err!("EOR\n");
+    assert_assemble_err!("EOR");
 
     // Relative
     assert_assemble_err!("EOR -44");
@@ -793,7 +793,7 @@ fn clc() {
     assert_assemble_err!("CLC #$44");
 
     // Implied
-    assert_assemble!("CLC\n", &[0x18]);
+    assert_assemble!("CLC", &[0x18]);
 
     // Relative
     assert_assemble_err!("CLC -44");
@@ -835,7 +835,7 @@ fn cld() {
     assert_assemble_err!("CLD #$44");
 
     // Implied
-    assert_assemble!("CLD\n", &[0xd8]);
+    assert_assemble!("CLD", &[0xd8]);
 
     // Relative
     assert_assemble_err!("CLD -44");
@@ -877,7 +877,7 @@ fn cli() {
     assert_assemble_err!("CLI #$44");
 
     // Implied
-    assert_assemble!("CLI\n", &[0x58]);
+    assert_assemble!("CLI", &[0x58]);
 
     // Relative
     assert_assemble_err!("CLI -44");
@@ -919,7 +919,7 @@ fn clv() {
     assert_assemble_err!("CLV #$44");
 
     // Implied
-    assert_assemble!("CLV\n", &[0xb8]);
+    assert_assemble!("CLV", &[0xb8]);
 
     // Relative
     assert_assemble_err!("CLV -44");
@@ -961,7 +961,7 @@ fn sec() {
     assert_assemble_err!("SEC #$44");
 
     // Implied
-    assert_assemble!("SEC\n", &[0x38]);
+    assert_assemble!("SEC", &[0x38]);
 
     // Relative
     assert_assemble_err!("SEC -44");
@@ -1003,7 +1003,7 @@ fn sed() {
     assert_assemble_err!("SED #$44");
 
     // Implied
-    assert_assemble!("SED\n", &[0xf8]);
+    assert_assemble!("SED", &[0xf8]);
 
     // Relative
     assert_assemble_err!("SED -44");
@@ -1045,7 +1045,7 @@ fn sei() {
     assert_assemble_err!("SEI #$44");
 
     // Implied
-    assert_assemble!("SEI\n", &[0x78]);
+    assert_assemble!("SEI", &[0x78]);
 
     // Relative
     assert_assemble_err!("SEI -44");
@@ -1087,7 +1087,7 @@ fn inc() {
     assert_assemble_err!("INC #$44");
 
     // Implied
-    assert_assemble_err!("INC\n");
+    assert_assemble_err!("INC");
 
     // Relative
     assert_assemble_err!("INC -44");
@@ -1129,7 +1129,7 @@ fn jmp() {
     assert_assemble_err!("JMP #$44");
 
     // Implied
-    assert_assemble_err!("JMP\n");
+    assert_assemble_err!("JMP");
 
     // Relative
     assert_assemble_err!("JMP -44");
@@ -1171,7 +1171,7 @@ fn jsr() {
     assert_assemble_err!("JSR #$44");
 
     // Implied
-    assert_assemble_err!("JSR\n");
+    assert_assemble_err!("JSR");
 
     // Relative
     assert_assemble_err!("JSR -44");
@@ -1213,7 +1213,7 @@ fn lda() {
     assert_assemble!("LDA #$44", &[0xa9, 0x44]);
 
     // Implied
-    assert_assemble_err!("LDA\n");
+    assert_assemble_err!("LDA");
 
     // Relative
     assert_assemble_err!("LDA -44");
@@ -1255,7 +1255,7 @@ fn ldx() {
     assert_assemble!("LDX #$44", &[0xa2, 0x44]);
 
     // Implied
-    assert_assemble_err!("LDX\n");
+    assert_assemble_err!("LDX");
 
     // Relative
     assert_assemble_err!("LDX -44");
@@ -1297,7 +1297,7 @@ fn ldy() {
     assert_assemble!("LDY #$44", &[0xa0, 0x44]);
 
     // Implied
-    assert_assemble_err!("LDY\n");
+    assert_assemble_err!("LDY");
 
     // Relative
     assert_assemble_err!("LDY -44");
@@ -1339,7 +1339,7 @@ fn lsr() {
     assert_assemble_err!("LSR #$44");
 
     // Implied
-    assert_assemble_err!("LSR\n");
+    assert_assemble_err!("LSR");
 
     // Relative
     assert_assemble_err!("LSR -44");
@@ -1381,7 +1381,7 @@ fn nop() {
     assert_assemble_err!("NOP #$44");
 
     // Implied
-    assert_assemble!("NOP\n", &[0xea]);
+    assert_assemble!("NOP", &[0xea]);
 
     // Relative
     assert_assemble_err!("NOP -44");
@@ -1423,7 +1423,7 @@ fn ora() {
     assert_assemble!("ORA #$44", &[0x09, 0x44]);
 
     // Implied
-    assert_assemble_err!("ORA\n");
+    assert_assemble_err!("ORA");
 
     // Relative
     assert_assemble_err!("ORA -44");
@@ -1465,7 +1465,7 @@ fn tax() {
     assert_assemble_err!("TAX #$44");
 
     // Implied
-    assert_assemble!("TAX\n", &[0xaa]);
+    assert_assemble!("TAX", &[0xaa]);
 
     // Relative
     assert_assemble_err!("TAX -44");
@@ -1507,7 +1507,7 @@ fn txa() {
     assert_assemble_err!("TXA #$44");
 
     // Implied
-    assert_assemble!("TXA\n", &[0x8a]);
+    assert_assemble!("TXA", &[0x8a]);
 
     // Relative
     assert_assemble_err!("TXA -44");
@@ -1549,7 +1549,7 @@ fn dex() {
     assert_assemble_err!("DEX #$44");
 
     // Implied
-    assert_assemble!("DEX\n", &[0xca]);
+    assert_assemble!("DEX", &[0xca]);
 
     // Relative
     assert_assemble_err!("DEX -44");
@@ -1591,7 +1591,7 @@ fn inx() {
     assert_assemble_err!("INX #$44");
 
     // Implied
-    assert_assemble!("INX\n", &[0xe8]);
+    assert_assemble!("INX", &[0xe8]);
 
     // Relative
     assert_assemble_err!("INX -44");
@@ -1633,7 +1633,7 @@ fn tay() {
     assert_assemble_err!("TAY #$44");
 
     // Implied
-    assert_assemble!("TAY\n", &[0xa8]);
+    assert_assemble!("TAY", &[0xa8]);
 
     // Relative
     assert_assemble_err!("TAY -44");
@@ -1675,7 +1675,7 @@ fn tya() {
     assert_assemble_err!("TYA #$44");
 
     // Implied
-    assert_assemble!("TYA\n", &[0x98]);
+    assert_assemble!("TYA", &[0x98]);
 
     // Relative
     assert_assemble_err!("TYA -44");
@@ -1717,7 +1717,7 @@ fn dey() {
     assert_assemble_err!("DEY #$44");
 
     // Implied
-    assert_assemble!("DEY\n", &[0x88]);
+    assert_assemble!("DEY", &[0x88]);
 
     // Relative
     assert_assemble_err!("DEY -44");
@@ -1759,7 +1759,7 @@ fn iny() {
     assert_assemble_err!("INY #$44");
 
     // Implied
-    assert_assemble!("INY\n", &[0xc8]);
+    assert_assemble!("INY", &[0xc8]);
 
     // Relative
     assert_assemble_err!("INY -44");
@@ -1801,7 +1801,7 @@ fn rol() {
     assert_assemble_err!("ROL #$44");
 
     // Implied
-    assert_assemble_err!("ROL\n");
+    assert_assemble_err!("ROL");
 
     // Relative
     assert_assemble_err!("ROL -44");
@@ -1843,7 +1843,7 @@ fn ror() {
     assert_assemble_err!("ROR #$44");
 
     // Implied
-    assert_assemble_err!("ROR\n");
+    assert_assemble_err!("ROR");
 
     // Relative
     assert_assemble_err!("ROR -44");
@@ -1885,7 +1885,7 @@ fn rti() {
     assert_assemble_err!("RTI #$44");
 
     // Implied
-    assert_assemble!("RTI\n", &[0x40]);
+    assert_assemble!("RTI", &[0x40]);
 
     // Relative
     assert_assemble_err!("RTI -44");
@@ -1927,7 +1927,7 @@ fn rts() {
     assert_assemble_err!("RTS #$44");
 
     // Implied
-    assert_assemble!("RTS\n", &[0x60]);
+    assert_assemble!("RTS", &[0x60]);
 
     // Relative
     assert_assemble_err!("RTS -44");
@@ -1969,7 +1969,7 @@ fn sbc() {
     assert_assemble!("SBC #$44", &[0xe9, 0x44]);
 
     // Implied
-    assert_assemble_err!("SBC\n");
+    assert_assemble_err!("SBC");
 
     // Relative
     assert_assemble_err!("SBC -44");
@@ -2011,7 +2011,7 @@ fn sta() {
     assert_assemble_err!("STA #$44");
 
     // Implied
-    assert_assemble_err!("STA\n");
+    assert_assemble_err!("STA");
 
     // Relative
     assert_assemble_err!("STA -44");
@@ -2053,7 +2053,7 @@ fn txs() {
     assert_assemble_err!("TXS #$44");
 
     // Implied
-    assert_assemble!("TXS\n", &[0x9a]);
+    assert_assemble!("TXS", &[0x9a]);
 
     // Relative
     assert_assemble_err!("TXS -44");
@@ -2095,7 +2095,7 @@ fn tsx() {
     assert_assemble_err!("TSX #$44");
 
     // Implied
-    assert_assemble!("TSX\n", &[0xba]);
+    assert_assemble!("TSX", &[0xba]);
 
     // Relative
     assert_assemble_err!("TSX -44");
@@ -2137,7 +2137,7 @@ fn pha() {
     assert_assemble_err!("PHA #$44");
 
     // Implied
-    assert_assemble!("PHA\n", &[0x48]);
+    assert_assemble!("PHA", &[0x48]);
 
     // Relative
     assert_assemble_err!("PHA -44");
@@ -2179,7 +2179,7 @@ fn pla() {
     assert_assemble_err!("PLA #$44");
 
     // Implied
-    assert_assemble!("PLA\n", &[0x68]);
+    assert_assemble!("PLA", &[0x68]);
 
     // Relative
     assert_assemble_err!("PLA -44");
@@ -2221,7 +2221,7 @@ fn php() {
     assert_assemble_err!("PHP #$44");
 
     // Implied
-    assert_assemble!("PHP\n", &[0x08]);
+    assert_assemble!("PHP", &[0x08]);
 
     // Relative
     assert_assemble_err!("PHP -44");
@@ -2263,7 +2263,7 @@ fn plp() {
     assert_assemble_err!("PLP #$44");
 
     // Implied
-    assert_assemble!("PLP\n", &[0x28]);
+    assert_assemble!("PLP", &[0x28]);
 
     // Relative
     assert_assemble_err!("PLP -44");
@@ -2305,7 +2305,7 @@ fn stx() {
     assert_assemble_err!("STX #$44");
 
     // Implied
-    assert_assemble_err!("STX\n");
+    assert_assemble_err!("STX");
 
     // Relative
     assert_assemble_err!("STX -44");
@@ -2347,7 +2347,7 @@ fn sty() {
     assert_assemble_err!("STY #$44");
 
     // Implied
-    assert_assemble_err!("STY\n");
+    assert_assemble_err!("STY");
 
     // Relative
     assert_assemble_err!("STY -44");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate nom;
 
 mod assembler;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,321 +1,299 @@
 #[cfg(test)]
 mod tests;
 
-use nom::{ErrorKind, IResult, line_ending, space};
 use crate::tokens::*;
+use nom::error::ErrorKind;
+use nom::IResult;
+use nom::{
+    branch::alt,
+    bytes::complete::{tag, tag_no_case},
+    character::complete::{line_ending, space1},
+    combinator::{eof, map, opt, value},
+    multi::separated_list0,
+    sequence::{delimited, preceded, separated_pair, terminated, tuple},
+};
 
-named!(pub parse_lines <Vec<OpCode> >, separated_list!(line_ending, opcode));
+pub fn parse_lines(input: &[u8]) -> IResult<&[u8], Vec<OpCode>> {
+    separated_list0(line_ending, opcode)(input)
+}
 
-named!(opcode <OpCode>, do_parse!(
-        mnemonic: mnemonic >>
-        am: addressing_mode >>
-        (OpCode(mnemonic, am))
-    )
-);
+fn opcode(input: &[u8]) -> IResult<&[u8], OpCode> {
+    let (input, (mnemonic, am)) = separated_pair(
+        mnemonic,
+        alt((space1, line_ending, eof)),
+        addressing_mode,
+    )(input)?;
+    Ok((input, OpCode(mnemonic, am)))
+}
 
-named!(mnemonic <Mnemonic>, alt!(
-        tag_no_case!("ADC") => { |_| Mnemonic::Adc } |
-        tag_no_case!("AND") => { |_| Mnemonic::And } |
-        tag_no_case!("ASL") => { |_| Mnemonic::Asl } |
-        tag_no_case!("BCC") => { |_| Mnemonic::Bcc } |
-        tag_no_case!("BCS") => { |_| Mnemonic::Bcs } |
-        tag_no_case!("BEQ") => { |_| Mnemonic::Beq } |
-        tag_no_case!("BIT") => { |_| Mnemonic::Bit } |
-        tag_no_case!("BMI") => { |_| Mnemonic::Bmi } |
-        tag_no_case!("BNE") => { |_| Mnemonic::Bne } |
-        tag_no_case!("BPL") => { |_| Mnemonic::Bpl } |
-        tag_no_case!("BRK") => { |_| Mnemonic::Brk } |
-        tag_no_case!("BVC") => { |_| Mnemonic::Bvc } |
-        tag_no_case!("BVS") => { |_| Mnemonic::Bvs } |
-        tag_no_case!("CLC") => { |_| Mnemonic::Clc } |
-        tag_no_case!("CLD") => { |_| Mnemonic::Cld } |
-        tag_no_case!("CLI") => { |_| Mnemonic::Cli } |
-        tag_no_case!("CLV") => { |_| Mnemonic::Clv } |
-        tag_no_case!("CMP") => { |_| Mnemonic::Cmp } |
-        tag_no_case!("CPX") => { |_| Mnemonic::Cpx } |
-        tag_no_case!("CPY") => { |_| Mnemonic::Cpy } |
-        tag_no_case!("DEC") => { |_| Mnemonic::Dec } |
-        tag_no_case!("DEX") => { |_| Mnemonic::Dex } |
-        tag_no_case!("DEY") => { |_| Mnemonic::Dey } |
-        tag_no_case!("EOR") => { |_| Mnemonic::Eor } |
-        tag_no_case!("INC") => { |_| Mnemonic::Inc } |
-        tag_no_case!("INX") => { |_| Mnemonic::Inx } |
-        tag_no_case!("INY") => { |_| Mnemonic::Iny } |
-        tag_no_case!("JMP") => { |_| Mnemonic::Jmp } |
-        tag_no_case!("JSR") => { |_| Mnemonic::Jsr } |
-        tag_no_case!("LDA") => { |_| Mnemonic::Lda } |
-        tag_no_case!("LDX") => { |_| Mnemonic::Ldx } |
-        tag_no_case!("LDY") => { |_| Mnemonic::Ldy } |
-        tag_no_case!("LSR") => { |_| Mnemonic::Lsr } |
-        tag_no_case!("NOP") => { |_| Mnemonic::Nop } |
-        tag_no_case!("ORA") => { |_| Mnemonic::Ora } |
-        tag_no_case!("PHA") => { |_| Mnemonic::Pha } |
-        tag_no_case!("PHP") => { |_| Mnemonic::Php } |
-        tag_no_case!("PLA") => { |_| Mnemonic::Pla } |
-        tag_no_case!("PLP") => { |_| Mnemonic::Plp } |
-        tag_no_case!("ROL") => { |_| Mnemonic::Rol } |
-        tag_no_case!("ROR") => { |_| Mnemonic::Ror } |
-        tag_no_case!("RTI") => { |_| Mnemonic::Rti } |
-        tag_no_case!("RTS") => { |_| Mnemonic::Rts } |
-        tag_no_case!("SBC") => { |_| Mnemonic::Sbc } |
-        tag_no_case!("SEC") => { |_| Mnemonic::Sec } |
-        tag_no_case!("SED") => { |_| Mnemonic::Sed } |
-        tag_no_case!("SEI") => { |_| Mnemonic::Sei } |
-        tag_no_case!("STA") => { |_| Mnemonic::Sta } |
-        tag_no_case!("STX") => { |_| Mnemonic::Stx } |
-        tag_no_case!("STY") => { |_| Mnemonic::Sty } |
-        tag_no_case!("TAX") => { |_| Mnemonic::Tax } |
-        tag_no_case!("TAY") => { |_| Mnemonic::Tay } |
-        tag_no_case!("TSX") => { |_| Mnemonic::Tsx } |
-        tag_no_case!("TXA") => { |_| Mnemonic::Txa } |
-        tag_no_case!("TXS") => { |_| Mnemonic::Txs } |
-        tag_no_case!("TYA") => { |_| Mnemonic::Tya }
-        )
+fn mnemonic(input: &[u8]) -> IResult<&[u8], Mnemonic> {
+    alt((
+        alt((
+            value(Mnemonic::Adc, tag_no_case("ADC")),
+            value(Mnemonic::And, tag_no_case("AND")),
+            value(Mnemonic::Asl, tag_no_case("ASL")),
+            value(Mnemonic::Bcc, tag_no_case("BCC")),
+            value(Mnemonic::Bcs, tag_no_case("BCS")),
+            value(Mnemonic::Beq, tag_no_case("BEQ")),
+            value(Mnemonic::Bit, tag_no_case("BIT")),
+            value(Mnemonic::Bmi, tag_no_case("BMI")),
+            value(Mnemonic::Bne, tag_no_case("BNE")),
+            value(Mnemonic::Bpl, tag_no_case("BPL")),
+            value(Mnemonic::Brk, tag_no_case("BRK")),
+            value(Mnemonic::Bvc, tag_no_case("BVC")),
+            value(Mnemonic::Bvs, tag_no_case("BVS")),
+            value(Mnemonic::Clc, tag_no_case("CLC")),
+            value(Mnemonic::Cld, tag_no_case("CLD")),
+            value(Mnemonic::Cli, tag_no_case("CLI")),
+            value(Mnemonic::Clv, tag_no_case("CLV")),
+            value(Mnemonic::Cmp, tag_no_case("CMP")),
+            value(Mnemonic::Cpx, tag_no_case("CPX")),
+            value(Mnemonic::Cpy, tag_no_case("CPY")),
+            value(Mnemonic::Dec, tag_no_case("DEC")),
+        )),
+        alt((
+            value(Mnemonic::Dex, tag_no_case("DEX")),
+            value(Mnemonic::Dey, tag_no_case("DEY")),
+            value(Mnemonic::Eor, tag_no_case("EOR")),
+            value(Mnemonic::Inc, tag_no_case("INC")),
+            value(Mnemonic::Inx, tag_no_case("INX")),
+            value(Mnemonic::Iny, tag_no_case("INY")),
+            value(Mnemonic::Jmp, tag_no_case("JMP")),
+            value(Mnemonic::Jsr, tag_no_case("JSR")),
+            value(Mnemonic::Lda, tag_no_case("LDA")),
+            value(Mnemonic::Ldx, tag_no_case("LDX")),
+            value(Mnemonic::Ldy, tag_no_case("LDY")),
+            value(Mnemonic::Lsr, tag_no_case("LSR")),
+            value(Mnemonic::Nop, tag_no_case("NOP")),
+            value(Mnemonic::Ora, tag_no_case("ORA")),
+            value(Mnemonic::Pha, tag_no_case("PHA")),
+            value(Mnemonic::Php, tag_no_case("PHP")),
+            value(Mnemonic::Pla, tag_no_case("PLA")),
+            value(Mnemonic::Plp, tag_no_case("PLP")),
+            value(Mnemonic::Rol, tag_no_case("ROL")),
+            value(Mnemonic::Ror, tag_no_case("ROR")),
+            value(Mnemonic::Rti, tag_no_case("RTI")),
+        )),
+        alt((
+            value(Mnemonic::Rts, tag_no_case("RTS")),
+            value(Mnemonic::Sbc, tag_no_case("SBC")),
+            value(Mnemonic::Sec, tag_no_case("SEC")),
+            value(Mnemonic::Sed, tag_no_case("SED")),
+            value(Mnemonic::Sei, tag_no_case("SEI")),
+            value(Mnemonic::Sta, tag_no_case("STA")),
+            value(Mnemonic::Stx, tag_no_case("STX")),
+            value(Mnemonic::Sty, tag_no_case("STY")),
+            value(Mnemonic::Tax, tag_no_case("TAX")),
+            value(Mnemonic::Tay, tag_no_case("TAY")),
+            value(Mnemonic::Tsx, tag_no_case("TSX")),
+            value(Mnemonic::Txa, tag_no_case("TXA")),
+            value(Mnemonic::Txs, tag_no_case("TXS")),
+            value(Mnemonic::Tya, tag_no_case("TYA")),
+        )),
+    ))(input)
+}
+
+fn addressing_mode(input: &[u8]) -> IResult<&[u8], AddressingMode> {
+    alt((
+        am_accumulator,
+        am_immediate,
+        am_indirect,
+        am_indexed_indirect,
+        am_indirect_indexed,
+        am_zp_x,
+        am_zp_y,
+        am_zp_or_relative,
+        am_abs_x,
+        am_abs_y,
+        am_abs,
+        am_implied,
+    ))(input)
+}
+
+fn am_implied(input: &[u8]) -> IResult<&[u8], AddressingMode> {
+    value(AddressingMode::Implied, alt((line_ending, eof)))(input)
+}
+
+fn am_indirect(input: &[u8]) -> IResult<&[u8], AddressingMode> {
+    let parser = tuple((
+        tag("("),
+        alt((parse_word_hex, dec_u16)),
+        tag(")"),
+        nom::combinator::not(tag(",")),
+    ));
+    map(parser, |(_, val, _, _)| AddressingMode::Indirect(val))(input)
+}
+
+fn am_indexed_indirect(input: &[u8]) -> IResult<&[u8], AddressingMode> {
+    let parser = delimited(
+        tag("("),
+        alt((parse_byte_hex, parse_byte_dec)),
+        tag_no_case(",X"),
     );
+    map(parser, |(addr, _)| AddressingMode::IndexedIndirect(addr))(input)
+}
 
-named!(addressing_mode <AddressingMode>,
-    alt_complete!(
-        am_accumulator |
-        am_immediate |
-        am_indirect |
-        am_indexed_indirect |
-        am_indirect_indexed |
-        am_zp_x |
-        am_zp_y |
-        am_zp_or_relative |
-        am_abs_x |
-        am_abs_y |
-        am_abs |
-        am_implied
-    )
-);
+fn am_indirect_indexed(input: &[u8]) -> IResult<&[u8], AddressingMode> {
+    let parser = delimited(
+        tag("("),
+        alt((parse_byte_hex, parse_byte_dec)),
+        tag_no_case("),Y"),
+    );
+    map(parser, |(addr, _)| AddressingMode::IndirectIndexed(addr))(input)
+}
 
-named!(am_implied <AddressingMode>,
-   do_parse!(
-       line_ending >>
-       (AddressingMode::Implied)
-   )
-);
+fn am_accumulator(input: &[u8]) -> IResult<&[u8], AddressingMode> {
+    map(tag_no_case("A"), |_| AddressingMode::Accumulator)(input)
+}
 
-named!(am_indirect <AddressingMode>,
-    do_parse!(
-        space >>
-        word: delimited!(tag!("("), alt!(parse_word_hex | dec_u16), tag!(")")) >>
-        not!(tag!(",")) >>
-        (AddressingMode::Indirect(word))
-    )
-);
+fn am_immediate(input: &[u8]) -> IResult<&[u8], AddressingMode> {
+    let parser = preceded(tag("#"), alt((parse_byte_hex, parse_byte_dec)));
+    map(parser, |(byte, sign)| AddressingMode::Immediate(byte, sign))(input)
+}
 
-named!(am_indexed_indirect <AddressingMode>,
-    do_parse!(
-        space >>
-        byte: delimited!(tag!("("), alt!(parse_byte_hex | parse_byte_dec), tag_no_case!(",X")) >>
-        ({ let (addr, _) = byte; AddressingMode::IndexedIndirect(addr) })
-    )
-);
+fn am_abs(input: &[u8]) -> IResult<&[u8], AddressingMode> {
+    let parser = alt((parse_word_hex, dec_u16));
+    map(parser, |val| AddressingMode::Absolute(val))(input)
+}
 
-named!(am_indirect_indexed <AddressingMode>,
-    do_parse!(
-        space >>
-        byte: delimited!(tag!("("), alt!(parse_byte_hex | parse_byte_dec), tag_no_case!("),Y")) >>
-        ({ let (addr, _) = byte; AddressingMode::IndirectIndexed(addr) })
-    )
-);
+fn am_zp_or_relative(input: &[u8]) -> IResult<&[u8], AddressingMode> {
+    let parser = alt((parse_byte_hex, parse_byte_dec));
+    map(parser, |(byte, sign)| {
+        AddressingMode::ZeroPageOrRelative(byte, sign)
+    })(input)
+}
 
-named!(am_accumulator <AddressingMode>,
-    do_parse!(
-        space >>
-        tag_no_case!("A") >>
-        (AddressingMode::Accumulator)
-    )
-);
+fn am_zp_x(input: &[u8]) -> IResult<&[u8], AddressingMode> {
+    let parser = terminated(alt((parse_byte_hex, parse_byte_dec)), tag_no_case(",X"));
+    map(parser, |(byte, _)| AddressingMode::ZeroPageX(byte))(input)
+}
 
-named!(am_immediate <AddressingMode>,
-    do_parse!(
-        space >>
-        val: preceded!(tag!("#"), alt!(parse_byte_hex | parse_byte_dec)) >>
-        ({ let (byte, sign) = val; AddressingMode::Immediate(byte, sign)})
-    )
-);
+fn am_zp_y(input: &[u8]) -> IResult<&[u8], AddressingMode> {
+    let parser = terminated(alt((parse_byte_hex, parse_byte_dec)), tag_no_case(",Y"));
+    map(parser, |(byte, _)| AddressingMode::ZeroPageY(byte))(input)
+}
 
-named!(am_abs <AddressingMode>,
-    do_parse!(
-        space >>
-        val: alt!(parse_word_hex | dec_u16) >>
-        (AddressingMode::Absolute(val))
-    )
-);
+fn am_abs_x(input: &[u8]) -> IResult<&[u8], AddressingMode> {
+    let parser = terminated(alt((parse_word_hex, dec_u16)), tag_no_case(",X"));
+    map(parser, |val| AddressingMode::AbsoluteX(val))(input)
+}
 
-named!(am_zp_or_relative <AddressingMode>,
-    do_parse!(
-        space >>
-        val: alt!(parse_byte_hex | parse_byte_dec) >>
-        ({ let (byte, sign) = val; AddressingMode::ZeroPageOrRelative(byte, sign)})
-    )
-);
+fn am_abs_y(input: &[u8]) -> IResult<&[u8], AddressingMode> {
+    let parser = terminated(alt((parse_word_hex, dec_u16)), tag_no_case(",Y"));
+    map(parser, |val| AddressingMode::AbsoluteY(val))(input)
+}
 
-named!(am_zp_x <AddressingMode>,
-    do_parse!(
-        space >>
-        val: terminated!(alt!(parse_byte_hex | parse_byte_dec), tag_no_case!(",X")) >>
-        ({ let (byte, _) = val; AddressingMode::ZeroPageX(byte)})
-    )
-);
+fn parse_word_hex(input: &[u8]) -> IResult<&[u8], u16> {
+    preceded(tag("$"), hex_u16)(input)
+}
 
-named!(am_zp_y <AddressingMode>,
-    do_parse!(
-        space >>
-        val: terminated!(alt!(parse_byte_hex | parse_byte_dec), tag_no_case!(",Y")) >>
-        ({ let (byte, _) = val; AddressingMode::ZeroPageY(byte)})
-    )
-);
+fn parse_byte_hex(input: &[u8]) -> IResult<&[u8], (u8, Sign)> {
+    map(preceded(tag("$"), hex_u8), |val| (val, Sign::Implied))(input)
+}
 
-named!(am_abs_x <AddressingMode>,
-    do_parse!(
-        space >>
-        val: terminated!(alt!(parse_word_hex | dec_u16), tag_no_case!(",X")) >>
-        (AddressingMode::AbsoluteX(val))
-    )
-);
+fn parse_byte_dec(input: &[u8]) -> IResult<&[u8], (u8, Sign)> {
+    map(tuple((parse_sign, dec_u8)), |(sign, val)| (val, sign))(input)
+}
 
-named!(am_abs_y <AddressingMode>,
-    do_parse!(
-        space >>
-        val: terminated!(alt!(parse_word_hex | dec_u16), tag_no_case!(",Y")) >>
-        (AddressingMode::AbsoluteY(val))
-    )
-);
-
-named!(parse_word_hex <u16>,
-    do_parse!(
-        val: preceded!(tag!("$"), hex_u16) >>
-        (val)
-    )
-);
-
-named!(parse_byte_hex <(u8, Sign)>,
-    do_parse!(
-        val: preceded!(tag!("$"), hex_u8) >>
-        (val, Sign::Implied)
-    )
-);
-
-named!(parse_byte_dec <(u8, Sign)>,
-    do_parse!(
-        sign: parse_sign >>
-        val: dec_u8 >>
-        (val, sign)
-    )
-);
-
-named!(parse_sign <Sign>,
-    do_parse!(
-        sign: opt!(tag!("-")) >>
-        (if let Some(_) = sign {
+fn parse_sign(input: &[u8]) -> IResult<&[u8], Sign> {
+    map(opt(tag("-")), |sign| {
+        if sign.is_some() {
             Sign::Negative
         } else {
             Sign::Implied
-        })
-    )
-);
+        }
+    })(input)
+}
 
-#[inline]
-pub fn hex_u16(input: &[u8]) -> IResult<&[u8], u16> {
-    match is_a!(input, &b"0123456789abcdefABCDEF"[..]) {
-        IResult::Error(e) => IResult::Error(e),
-        IResult::Incomplete(e) => IResult::Incomplete(e),
-        IResult::Done(i, o) => {
-            let mut res = 0u16;
+fn hex_u16(input: &[u8]) -> IResult<&[u8], u16> {
+    let (i, o) = nom::bytes::complete::is_a(&b"0123456789abcdefABCDEF"[..])(input)?;
+    let mut res = 0u16;
 
-            // Do not parse more than 4 characters for a u16
-            let mut remaining = i;
-            let mut parsed = o;
-            if o.len() > 4 {
-                remaining = &input[4..];
-                parsed = &input[..4];
-            }
+    // Do not parse more than 4 characters for a u16
+    let mut remaining = i;
+    let mut parsed = o;
+    if o.len() > 4 {
+        remaining = &input[4..];
+        parsed = &input[..4];
+    }
 
-            for &e in parsed {
-                let digit = e as char;
-                let value = digit.to_digit(16).unwrap_or(0) as u16;
-                res = value + (res << 4);
-            }
-            IResult::Done(remaining, res)
+    for &e in parsed {
+        let digit = e as char;
+        let value = digit.to_digit(16).unwrap_or(0) as u16;
+        res = value + (res << 4);
+    }
+    IResult::Ok((remaining, res))
+}
+
+fn dec_u16(input: &[u8]) -> IResult<&[u8], u16> {
+    let (remaining, parsed) = nom::bytes::complete::is_a(&b"0123456789"[..])(input)?;
+    // Do not parse more than 5 characters for a u16
+    if parsed.len() > 5 {
+        IResult::Err(nom::Err::Error(nom::error::make_error(
+            input,
+            ErrorKind::TooLarge,
+        )))
+    } else {
+        let mut res = 0u32;
+        for &e in parsed {
+            let digit = e as char;
+            let value = digit.to_digit(10).unwrap_or(0) as u32;
+            res = value + (res * 10);
+        }
+        if res > u16::max_value() as u32 {
+            // TODO: propper error handling. ErrorKind::TooLarge probably is not
+            // the best choice here. Some custome error?
+            IResult::Err(nom::Err::Error(nom::error::make_error(
+                input,
+                ErrorKind::TooLarge,
+            )))
+        } else {
+            IResult::Ok((remaining, res as u16))
         }
     }
 }
 
-#[inline]
-pub fn dec_u16(input: &[u8]) -> IResult<&[u8], u16> {
-    match is_a!(input, &b"0123456789"[..]) {
-        IResult::Error(e) => IResult::Error(e),
-        IResult::Incomplete(e) => IResult::Incomplete(e),
-        IResult::Done(remaining, parsed) => {
-            // Do not parse more than 5 characters for a u16
-            if parsed.len() > 5 {
-                IResult::Error(ErrorKind::Custom(0))
-            } else {
-                let mut res = 0u32;
-                for &e in parsed {
-                    let digit = e as char;
-                    let value = digit.to_digit(10).unwrap_or(0) as u32;
-                    res = value + (res * 10);
-                }
-                if res > u16::max_value() as u32 {
-                    IResult::Error(ErrorKind::Custom(0))
-                } else {
-                    IResult::Done(remaining, res as u16)
-                }
-            }
+fn dec_u8(input: &[u8]) -> IResult<&[u8], u8> {
+    let (remaining, parsed) = nom::bytes::complete::is_a(&b"0123456789"[..])(input)?;
+    // Do not parse more than 3 characters for a u16
+    if parsed.len() > 3 {
+        IResult::Err(nom::Err::Error(nom::error::make_error(
+            input,
+            ErrorKind::TooLarge,
+        )))
+    } else {
+        let mut res = 0u16;
+        for &e in parsed {
+            let digit = e as char;
+            let value = digit.to_digit(10).unwrap_or(0) as u16;
+            res = value + (res * 10);
+        }
+        if res > u8::max_value() as u16 {
+            IResult::Err(nom::Err::Error(nom::error::make_error(
+                input,
+                ErrorKind::TooLarge,
+            )))
+        } else {
+            IResult::Ok((remaining, res as u8))
         }
     }
 }
 
-#[inline]
-pub fn dec_u8(input: &[u8]) -> IResult<&[u8], u8> {
-    match is_a!(input, &b"0123456789"[..]) {
-        IResult::Error(e) => IResult::Error(e),
-        IResult::Incomplete(e) => IResult::Incomplete(e),
-        IResult::Done(remaining, parsed) => {
-            // Do not parse more than 3 characters for a u16
-            if parsed.len() > 3 {
-                IResult::Error(ErrorKind::Custom(0))
-            } else {
-                let mut res = 0u16;
-                for &e in parsed {
-                    let digit = e as char;
-                    let value = digit.to_digit(10).unwrap_or(0) as u16;
-                    res = value + (res * 10);
-                }
-                if res > u8::max_value() as u16 {
-                    IResult::Error(ErrorKind::Custom(0))
-                } else {
-                    IResult::Done(remaining, res as u8)
-                }
-            }
-        }
-    }
-}
-
-#[inline]
 fn hex_u8(input: &[u8]) -> IResult<&[u8], u8> {
-    match is_a!(input, &b"0123456789abcdefABCDEF"[..]) {
-        IResult::Error(e) => IResult::Error(e),
-        IResult::Incomplete(e) => IResult::Incomplete(e),
-        IResult::Done(remaining, parsed) => {
-            // Not valid if exceeds 2 characters
-            if parsed.len() > 2 {
-                IResult::Error(ErrorKind::Custom(0))
-            } else {
-                let mut res = 0u8;
-                for &e in parsed {
-                    let digit = e as char;
-                    let value = digit.to_digit(16).unwrap_or(0) as u8;
-                    res = value + (res << 4);
-                }
-                IResult::Done(remaining, res)
-            }
-
+    let (remaining, parsed) = nom::bytes::complete::is_a(&b"0123456789abcdefABCDEF"[..])(input)?;
+    // Not valid if exceeds 2 characters
+    if parsed.len() > 2 {
+        IResult::Err(nom::Err::Error(nom::error::make_error(
+            input,
+            ErrorKind::TooLarge,
+        )))
+    } else {
+        let mut res = 0u8;
+        for &e in parsed {
+            let digit = e as char;
+            let value = digit.to_digit(16).unwrap_or(0) as u8;
+            res = value + (res << 4);
         }
+        IResult::Ok((remaining, res))
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -2,7 +2,7 @@
 mod tests;
 
 use nom::{ErrorKind, IResult, line_ending, space};
-use tokens::*;
+use crate::tokens::*;
 
 named!(pub parse_lines <Vec<OpCode> >, separated_list!(line_ending, opcode));
 

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -1,6 +1,6 @@
 use nom::IResult;
-use parser::*;
-use tokens::*;
+use crate::parser::*;
+use crate::tokens::*;
 
 macro_rules! assert_parse {
     ( $ left : expr , $ right : expr ) => {

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -4,7 +4,7 @@ use crate::tokens::*;
 
 macro_rules! assert_parse {
     ( $ left : expr , $ right : expr ) => {
-        if let IResult::Done(_, actual) = $right {
+        if let IResult::Ok((_, actual)) = $right {
             assert_eq!($left, actual)
         } else {
             panic!("Expected parse result to be {:?}, but parsing failed with: {:?}",
@@ -35,8 +35,11 @@ macro_rules! assert_mnemonic_parse {
 
 macro_rules! assert_parse_fail {
     ( $ result : expr ) => {
-        if let IResult::Done(_, actual) = $result {
-            panic!("Expected parsing to fail, but it succeeded with: {:?}", actual);
+        if let IResult::Ok((_, actual)) = $result {
+            panic!(
+                "Expected parsing to fail, but it succeeded with: {:?}",
+                actual
+            );
         }
     };
 }
@@ -103,156 +106,163 @@ fn parse_mnemonic() {
 
 #[test]
 fn parse_accumulator() {
-    assert_am_parse!(" A", AddressingMode::Accumulator);
+    assert_am_parse!("A", AddressingMode::Accumulator);
 }
 
 #[test]
 fn parse_immediate_hex() {
-    assert_am_parse!(" #$1", AddressingMode::Immediate(0x1, Sign::Implied));
-    assert_am_parse!(" #$10", AddressingMode::Immediate(0x10, Sign::Implied));
-    assert_am_parse!(" #$ff", AddressingMode::Immediate(0xff, Sign::Implied));
+    assert_am_parse!("#$1", AddressingMode::Immediate(0x1, Sign::Implied));
+    assert_am_parse!("#$10", AddressingMode::Immediate(0x10, Sign::Implied));
+    assert_am_parse!("#$ff", AddressingMode::Immediate(0xff, Sign::Implied));
     assert_parse_fail!(addressing_mode(" #$100".as_bytes()));
 }
 
 #[test]
 fn parse_immediate_dec() {
-    assert_am_parse!(" #1", AddressingMode::Immediate(1, Sign::Implied));
-    assert_am_parse!(" #10", AddressingMode::Immediate(10, Sign::Implied));
-    assert_am_parse!(" #255", AddressingMode::Immediate(255, Sign::Implied));
-    assert_am_parse!(" #-10", AddressingMode::Immediate(10, Sign::Negative));
+    assert_am_parse!("#1", AddressingMode::Immediate(1, Sign::Implied));
+    assert_am_parse!("#10", AddressingMode::Immediate(10, Sign::Implied));
+    assert_am_parse!("#255", AddressingMode::Immediate(255, Sign::Implied));
+    assert_am_parse!("#-10", AddressingMode::Immediate(10, Sign::Negative));
     assert_parse_fail!(addressing_mode(" #256".as_bytes()));
 }
 
 #[test]
 fn parse_absolute_x_hex() {
-    assert_am_parse!(" $ffff,X", AddressingMode::AbsoluteX(0xffff));
-    assert_am_parse!(" $1000,X", AddressingMode::AbsoluteX(0x1000));
-    assert_am_parse!(" $100,X", AddressingMode::AbsoluteX(0x100));
+    assert_am_parse!("$ffff,X", AddressingMode::AbsoluteX(0xffff));
+    assert_am_parse!("$1000,X", AddressingMode::AbsoluteX(0x1000));
+    assert_am_parse!("$100,X", AddressingMode::AbsoluteX(0x100));
 }
 
 #[test]
 fn parse_absolute_x_dec() {
-    assert_am_parse!(" 65535,X", AddressingMode::AbsoluteX(65535));
-    assert_am_parse!(" 1000,X", AddressingMode::AbsoluteX(1000));
-    assert_am_parse!(" 256,X", AddressingMode::AbsoluteX(256));
+    assert_am_parse!("65535,X", AddressingMode::AbsoluteX(65535));
+    assert_am_parse!("1000,X", AddressingMode::AbsoluteX(1000));
+    assert_am_parse!("256,X", AddressingMode::AbsoluteX(256));
 }
 
 #[test]
 fn parse_absolute_y_hex() {
-    assert_am_parse!(" $ffff,Y", AddressingMode::AbsoluteY(0xffff));
-    assert_am_parse!(" $1000,Y", AddressingMode::AbsoluteY(0x1000));
-    assert_am_parse!(" $100,Y", AddressingMode::AbsoluteY(0x100));
+    assert_am_parse!("$ffff,Y", AddressingMode::AbsoluteY(0xffff));
+    assert_am_parse!("$1000,Y", AddressingMode::AbsoluteY(0x1000));
+    assert_am_parse!("$100,Y", AddressingMode::AbsoluteY(0x100));
 }
 
 #[test]
 fn parse_absolute_y_dec() {
-    assert_am_parse!(" 65535,Y", AddressingMode::AbsoluteY(65535));
-    assert_am_parse!(" 1000,Y", AddressingMode::AbsoluteY(1000));
-    assert_am_parse!(" 256,Y", AddressingMode::AbsoluteY(256));
+    assert_am_parse!("65535,Y", AddressingMode::AbsoluteY(65535));
+    assert_am_parse!("1000,Y", AddressingMode::AbsoluteY(1000));
+    assert_am_parse!("256,Y", AddressingMode::AbsoluteY(256));
 }
 
 #[test]
 fn parse_indexed_indirect_hex() {
-    assert_am_parse!(" ($ff,X)", AddressingMode::IndexedIndirect(0xff));
-    assert_am_parse!(" ($0,X)", AddressingMode::IndexedIndirect(0x0));
-    assert_am_parse!(" ($10,X)", AddressingMode::IndexedIndirect(0x10));
+    assert_am_parse!("($ff,X)", AddressingMode::IndexedIndirect(0xff));
+    assert_am_parse!("($0,X)", AddressingMode::IndexedIndirect(0x0));
+    assert_am_parse!("($10,X)", AddressingMode::IndexedIndirect(0x10));
 }
 
 #[test]
 fn parse_indexed_indirect_dec() {
-    assert_am_parse!(" (255,X)", AddressingMode::IndexedIndirect(255));
-    assert_am_parse!(" (0,X)", AddressingMode::IndexedIndirect(0));
-    assert_am_parse!(" (10,X)", AddressingMode::IndexedIndirect(10));
+    assert_am_parse!("(255,X)", AddressingMode::IndexedIndirect(255));
+    assert_am_parse!("(0,X)", AddressingMode::IndexedIndirect(0));
+    assert_am_parse!("(10,X)", AddressingMode::IndexedIndirect(10));
 }
 
 #[test]
 fn parse_indirect_indexed_hex() {
-    assert_am_parse!(" ($ff),Y", AddressingMode::IndirectIndexed(0xff));
-    assert_am_parse!(" ($0),Y", AddressingMode::IndirectIndexed(0x0));
-    assert_am_parse!(" ($10),Y", AddressingMode::IndirectIndexed(0x10));
+    assert_am_parse!("($ff),Y", AddressingMode::IndirectIndexed(0xff));
+    assert_am_parse!("($0),Y", AddressingMode::IndirectIndexed(0x0));
+    assert_am_parse!("($10),Y", AddressingMode::IndirectIndexed(0x10));
 }
 
 #[test]
 fn parse_indirect_indexed_dec() {
-    assert_am_parse!(" (255),Y", AddressingMode::IndirectIndexed(255));
-    assert_am_parse!(" (0),Y", AddressingMode::IndirectIndexed(0));
-    assert_am_parse!(" (10),Y", AddressingMode::IndirectIndexed(10));
+    assert_am_parse!("(255),Y", AddressingMode::IndirectIndexed(255));
+    assert_am_parse!("(0),Y", AddressingMode::IndirectIndexed(0));
+    assert_am_parse!("(10),Y", AddressingMode::IndirectIndexed(10));
 }
 
 #[test]
 fn parse_indirect_hex() {
-    assert_am_parse!(" ($ffff)", AddressingMode::Indirect(0xffff));
-    assert_am_parse!(" ($00)", AddressingMode::Indirect(0x0));
-    assert_am_parse!(" ($100)", AddressingMode::Indirect(0x100));
+    assert_am_parse!("($ffff)", AddressingMode::Indirect(0xffff));
+    assert_am_parse!("($00)", AddressingMode::Indirect(0x0));
+    assert_am_parse!("($100)", AddressingMode::Indirect(0x100));
 }
 
 #[test]
 fn parse_indirect_dec() {
-    assert_am_parse!(" (65535)", AddressingMode::Indirect(65535));
-    assert_am_parse!(" (0)", AddressingMode::Indirect(0));
-    assert_am_parse!(" (10)", AddressingMode::Indirect(10));
+    assert_am_parse!("(65535)", AddressingMode::Indirect(65535));
+    assert_am_parse!("(0)", AddressingMode::Indirect(0));
+    assert_am_parse!("(10)", AddressingMode::Indirect(10));
 }
 
 #[test]
 fn parse_zero_page_or_relative_hex() {
-    assert_am_parse!(" $ff",
-                     AddressingMode::ZeroPageOrRelative(0xff, Sign::Implied));
-    assert_am_parse!(" $0",
-                     AddressingMode::ZeroPageOrRelative(0x0, Sign::Implied));
-    assert_am_parse!(" $10",
-                     AddressingMode::ZeroPageOrRelative(0x10, Sign::Implied));
+    assert_am_parse!(
+        "$ff",
+        AddressingMode::ZeroPageOrRelative(0xff, Sign::Implied)
+    );
+    assert_am_parse!("$0", AddressingMode::ZeroPageOrRelative(0x0, Sign::Implied));
+    assert_am_parse!(
+        "$10",
+        AddressingMode::ZeroPageOrRelative(0x10, Sign::Implied)
+    );
 }
 
 #[test]
 fn parse_zero_page_or_relative_dec() {
-    assert_am_parse!(" 255",
-                     AddressingMode::ZeroPageOrRelative(255, Sign::Implied));
-    assert_am_parse!(" 0", AddressingMode::ZeroPageOrRelative(0, Sign::Implied));
-    assert_am_parse!(" 10", AddressingMode::ZeroPageOrRelative(10, Sign::Implied));
-    assert_am_parse!(" -10",
-                     AddressingMode::ZeroPageOrRelative(10, Sign::Negative));
+    assert_am_parse!(
+        "255",
+        AddressingMode::ZeroPageOrRelative(255, Sign::Implied)
+    );
+    assert_am_parse!("0", AddressingMode::ZeroPageOrRelative(0, Sign::Implied));
+    assert_am_parse!("10", AddressingMode::ZeroPageOrRelative(10, Sign::Implied));
+    assert_am_parse!(
+        "-10",
+        AddressingMode::ZeroPageOrRelative(10, Sign::Negative)
+    );
 }
 
 #[test]
 fn parse_zero_page_x_hex() {
-    assert_am_parse!(" $ff,X", AddressingMode::ZeroPageX(0xff));
-    assert_am_parse!(" $0,X", AddressingMode::ZeroPageX(0x0));
-    assert_am_parse!(" $10,X", AddressingMode::ZeroPageX(0x10));
+    assert_am_parse!("$ff,X", AddressingMode::ZeroPageX(0xff));
+    assert_am_parse!("$0,X", AddressingMode::ZeroPageX(0x0));
+    assert_am_parse!("$10,X", AddressingMode::ZeroPageX(0x10));
 }
 
 #[test]
 fn parse_zero_page_x_dec() {
-    assert_am_parse!(" 255,X", AddressingMode::ZeroPageX(255));
-    assert_am_parse!(" 0,X", AddressingMode::ZeroPageX(0));
-    assert_am_parse!(" 10,X", AddressingMode::ZeroPageX(10));
+    assert_am_parse!("255,X", AddressingMode::ZeroPageX(255));
+    assert_am_parse!("0,X", AddressingMode::ZeroPageX(0));
+    assert_am_parse!("10,X", AddressingMode::ZeroPageX(10));
 }
 
 #[test]
 fn parse_zero_page_y_hex() {
-    assert_am_parse!(" $ff,Y", AddressingMode::ZeroPageY(0xff));
-    assert_am_parse!(" $0,Y", AddressingMode::ZeroPageY(0x0));
-    assert_am_parse!(" $10,Y", AddressingMode::ZeroPageY(0x10));
+    assert_am_parse!("$ff,Y", AddressingMode::ZeroPageY(0xff));
+    assert_am_parse!("$0,Y", AddressingMode::ZeroPageY(0x0));
+    assert_am_parse!("$10,Y", AddressingMode::ZeroPageY(0x10));
 }
 
 #[test]
 fn parse_zero_page_y_dec() {
-    assert_am_parse!(" 255,Y", AddressingMode::ZeroPageY(255));
-    assert_am_parse!(" 0,Y", AddressingMode::ZeroPageY(0));
-    assert_am_parse!(" 10,Y", AddressingMode::ZeroPageY(10));
+    assert_am_parse!("255,Y", AddressingMode::ZeroPageY(255));
+    assert_am_parse!("0,Y", AddressingMode::ZeroPageY(0));
+    assert_am_parse!("10,Y", AddressingMode::ZeroPageY(10));
 }
 
 #[test]
 fn parse_absolute_hex() {
-    assert_am_parse!(" $ffff", AddressingMode::Absolute(0xffff));
-    assert_am_parse!(" $1000", AddressingMode::Absolute(0x1000));
-    assert_am_parse!(" $100", AddressingMode::Absolute(0x100));
+    assert_am_parse!("$ffff", AddressingMode::Absolute(0xffff));
+    assert_am_parse!("$1000", AddressingMode::Absolute(0x1000));
+    assert_am_parse!("$100", AddressingMode::Absolute(0x100));
 }
 
 #[test]
 fn parse_absolute_dec() {
-    assert_am_parse!(" 65535", AddressingMode::Absolute(65535));
-    assert_am_parse!(" 1000", AddressingMode::Absolute(1000));
-    assert_am_parse!(" 256", AddressingMode::Absolute(256));
+    assert_am_parse!("65535", AddressingMode::Absolute(65535));
+    assert_am_parse!("1000", AddressingMode::Absolute(1000));
+    assert_am_parse!("256", AddressingMode::Absolute(256));
 }
 
 #[test]
@@ -269,8 +279,7 @@ fn parse_opcode() {
 #[test]
 fn parse_lines() {
     match super::parse_lines("ADC #1\nSBC $FFFF\nJMP ($ff00)\n".as_bytes()) {
-        IResult::Done(_, opcodes) => {
-            println!("{:?}", opcodes);
+        IResult::Ok((_, opcodes)) => {
             assert_eq!(3, opcodes.len());
             assert_eq!(OpCode(Mnemonic::Adc, AddressingMode::Immediate(1, Sign::Implied)),
                        opcodes[0]);
@@ -279,7 +288,6 @@ fn parse_lines() {
             assert_eq!(OpCode(Mnemonic::Jmp, AddressingMode::Indirect(0xff00)),
                        opcodes[2]);
         }
-        IResult::Error(e) => panic!("Parse lines failed with: {:?}", e),
-        IResult::Incomplete(e) => panic!("Parse lines failed with: {:?}", e),
+        IResult::Err(e) => panic!("Parse lines failed with: {:?}", e),
     }
 }

--- a/src/tokens/mod.rs
+++ b/src/tokens/mod.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Mnemonic {
     Adc,
     And,
@@ -58,14 +58,14 @@ pub enum Mnemonic {
     Tya,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Sign {
     Implied,
     Positive,
     Negative,
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum AddressingMode {
     IndexedIndirect(u8),
     IndirectIndexed(u8),


### PR DESCRIPTION
Hi.
It's all started with me trying to solve problem with implied instruction required `\n` at the end. Nom PR (linked in readme.md) was merged and I recon I've just need to update nom.
Well... Nom deprecated macros and in v7 they delete it. I wanted to update to version 6 (to make this PR smaller), but some macroses change they semantics, so it was just easier to get rid of macroses ones and for all.

This patch save code semantic for most of the parser code. See test code for changes (it's now accept implied instruction without `\n` and address mode parsers do not handle space between mnemonic and address mode)

ps. I am planing to make some more PRs to this repo. At least to make labels work.