### PR TITLE
Allow empty lines + set github actions CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-and-test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,3 +1,0 @@
-reorder_imports = true
-reorder_imported_names = true
-write_mode = "Overwrite"

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -7,14 +7,19 @@ use nom::IResult;
 use nom::{
     branch::alt,
     bytes::complete::{tag, tag_no_case},
-    character::complete::{line_ending, space0},
-    combinator::{eof, map, opt, peek, value},
+    character::complete::{line_ending, multispace0, multispace1, space0},
+    combinator::{all_consuming, eof, map, opt, peek, value},
     multi::separated_list0,
     sequence::{delimited, preceded, separated_pair, terminated, tuple},
 };
 
 pub fn parse_lines(input: &[u8]) -> IResult<&[u8], Vec<OpCode>> {
-    separated_list0(line_ending, opcode)(input)
+    let parser = all_consuming(tuple((
+        multispace0,
+        separated_list0(multispace1, opcode),
+        multispace0,
+    )));
+    map(parser, |(_, ops, _)| ops)(input)
 }
 
 fn opcode(input: &[u8]) -> IResult<&[u8], OpCode> {
@@ -124,7 +129,7 @@ fn am_indexed_indirect(input: &[u8]) -> IResult<&[u8], AddressingMode> {
     let parser = delimited(
         tag("("),
         alt((parse_byte_hex, parse_byte_dec)),
-        tag_no_case(",X"),
+        tag_no_case(",X)"),
     );
     map(parser, |(addr, _)| AddressingMode::IndexedIndirect(addr))(input)
 }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -312,3 +312,39 @@ fn several_implied_ops() {
     ];
     assert_eq!(parsed, Ok((&[] as &[u8], expected)));
 }
+
+#[test]
+fn empty_lines_in_front() {
+    let parsed = super::parse_lines("\n   \nNOP\nBRK".as_bytes());
+    let expected = vec![
+        OpCode(Mnemonic::Nop, AddressingMode::Implied),
+        OpCode(Mnemonic::Brk, AddressingMode::Implied),
+    ];
+    assert_eq!(parsed, Ok((&[] as &[u8], expected)));
+}
+
+#[test]
+fn empty_lines_in_middle() {
+    let parsed = super::parse_lines("NOP\n    \nBRK".as_bytes());
+    let expected = vec![
+        OpCode(Mnemonic::Nop, AddressingMode::Implied),
+        OpCode(Mnemonic::Brk, AddressingMode::Implied),
+    ];
+    assert_eq!(parsed, Ok((&[] as &[u8], expected)));
+}
+
+#[test]
+fn empty_lines_in_end() {
+    let parsed = super::parse_lines("NOP\nBRK  \n\n".as_bytes());
+    let expected = vec![
+        OpCode(Mnemonic::Nop, AddressingMode::Implied),
+        OpCode(Mnemonic::Brk, AddressingMode::Implied),
+    ];
+    assert_eq!(parsed, Ok((&[] as &[u8], expected)));
+}
+
+#[test]
+fn parsing_line_with_error() {
+    let parsed = super::parse_lines("LDX #ab".as_bytes());
+    assert!(parsed.is_err());
+}


### PR DESCRIPTION
fix #3 
Technically this is a breaking change, since now asm with errors return `Err`, instead of `Ok` with already parsed result. But I think this is desirable behavior.