### PR TITLE
Label support

### DIFF
--- a/src/assembler/tests.rs
+++ b/src/assembler/tests.rs
@@ -2367,3 +2367,29 @@ fn sty() {
     // ZeroPageY
     assert_assemble_err!("STY $44,Y");
 }
+
+#[test]
+fn branch_with_forward_label() {
+    let asm = "BVC LABEL\nNOP\nNOP\nLABEL:\nNOP".as_bytes();
+    let mut buf = Vec::<u8>::new();
+    let asm = assemble(asm, &mut buf);
+    assert!(asm.is_ok());
+    assert_eq!(buf, &[0x50, 0x02, 0xEA, 0xEA, 0xEA]);
+}
+
+#[test]
+fn branch_with_backward_label() {
+    let asm = "LABEL:\nNOP\nNOP\nBVC LABEL\nNOP".as_bytes();
+    let mut buf = Vec::<u8>::new();
+    let asm = assemble(asm, &mut buf);
+    assert!(asm.is_ok());
+    assert_eq!(buf, &[0xEA, 0xEA, 0x50, 0xFC, 0xEA]);
+}
+
+#[test]
+fn unknown_label() {
+    let asm = "LABEL:\nNOP\nBVC LABEL_new\nNOP".as_bytes();
+    let mut buf = Vec::<u8>::new();
+    let asm = assemble(asm, &mut buf);
+    assert!(asm.is_err());
+}

--- a/src/tokens/mod.rs
+++ b/src/tokens/mod.rs
@@ -65,7 +65,7 @@ pub enum Sign {
     Negative,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum AddressingMode {
     IndexedIndirect(u8),
     IndirectIndexed(u8),
@@ -79,7 +79,14 @@ pub enum AddressingMode {
     Indirect(u16),
     Implied,
     Accumulator,
+    Label(String),
 }
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct OpCode(pub Mnemonic, pub AddressingMode);
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum Token {
+    OpCode(OpCode),
+    Label(String),
+}


### PR DESCRIPTION
Now parse_lines return not `vec<OpCode>`, but `vec<Token>`.
Token may be OpCode or Label.

Assemble is 2 step process now.
1. Generate binary from opcodes.
    On that stage all opcodes that need lables position get relocate
    mark.

2. Relocation.
    Now we know all labels position, all places that need relocation set
    with concrete relative addresses.

There is one quirk: now `output` parameter of `assemble` function is
a waste since we cannot generate binary online anymore and need to hold
own copy of generated code. But we wan't break compatability at this
stage. Maybe on v1.0.

fix #1 